### PR TITLE
fix(branches): Use quotes for branches

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -15,25 +15,25 @@ content:
   sources:
     - url: https://github.com/bonitasoft/bonita-cloud-doc.git
       branches:
-        - master
+        - "master"
     - url: https://github.com/bonitasoft/bonita-doc.git
       branches:
-        - archives
-        - 7.5
-        - 7.6
-        - 7.7
-        - 7.8
-        - 7.9
-        - 7.10
-        - 7.11
-        - 2021.1
-        - 2021.2
+        - "archives"
+        - "7.5"
+        - "7.6"
+        - "7.7"
+        - "7.8"
+        - "7.9"
+        - "7.10"
+        - "7.11"
+        - "2021.1"
+        - "2021.2"
     - url: https://github.com/bonitasoft/bonita-ici-doc.git
       branches:
-        - master
+        - "master"
     - url: https://github.com/bonitasoft/bonita-continuous-delivery-doc.git
       branches:
-        - 3.4
+        - "3.4"
 ui:
   bundle:
     url: ./resources/antora-ui-bundle.zip


### PR DESCRIPTION
Without quotes, a branche like 7.10 is transformed to 7.1 at build time. it's annoying :)