### PR TITLE
feat: remove Bonita 2021.2 from the site

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -27,7 +27,6 @@ content:
         - "7.10"
         - "7.11"
         - "2021.1"
-        - "2021.2"
     - url: https://github.com/bonitasoft/bonita-ici-doc.git
       branches:
         - "master"


### PR DESCRIPTION
This version is alpha and we don't want to display it.