### PR TITLE
feat: redirect bici/latest

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -138,6 +138,10 @@ from = "/bici/1.3/*"
 to = "/labs/latest/bici/:splat"
 
 [[redirects]]
+from = "/bici/latest/*"
+to = "/labs/latest/bici/:splat"
+
+[[redirects]]
 from = "/ici/:version/*"
 to = "/labs/latest/bici/:splat"
 


### PR DESCRIPTION
Redirect to labs/latest/bici to ensure old urls are still working

This also requires https://github.com/bonitasoft/bonita-ici-doc/pull/130 to be merged.
closes #212