### PR TITLE
feat: Add _getting Started redirect to tutorial-overview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -34,6 +34,10 @@
 
 # TODO: Add redirect to Groovydoc
 
+# Bonita Community redirect to getting Started
+[[redirects]]
+  from = "/bonita/*/_getting-started-tutorial"
+  to = "/bonita/latest/tutorial-overview"
 
 ########################################
 # Bonita Old Documentation redirects to Archives


### PR DESCRIPTION
In the oldest documentation site, some pages were generated to allow users to get an index point on some taxonomy categories.

Now, these pages didn't exist and links are broken. We decided at this moment to only add a redirect on `bonita/xx/_getting-started-tutorial` to `bonita/latest/tutorial-overview`.

This page is a good entry point for users who comes from a community site for example.

The test environment is available here: https://bonitasoft-test-redirect.netlify.app/bonita/latest/tutorial-overview


Nb: We can't use Antora `:page-aliases: _getting_started_tutorial.adoc` in content. At generation time, the `_` throw an error and page is not generated