### PR TITLE
fix(bcd): Try fix default redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -88,6 +88,11 @@ to = "/bonita/0/"
 # BCD redirects
 ########################################
 [[redirects]]
+from = "/bcd/latest"
+to = "/bcd/latest/"
+status = 200
+
+[[redirects]]
 from = "/bcd/latest/*"
 to = "/bcd/3.5/:splat"
 status = 200


### PR DESCRIPTION
Image rendering is broken on home page because of missing ending slash in url. 

=> Redirect from "latest" to "latest/" as a workaround.