### PR TITLE
feat(redirect): Add redirect for next dev version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -43,6 +43,12 @@
   from = "/bonita/*/_getting-started-tutorial"
   to = "/bonita/latest/tutorial-overview"
 
+# Redirect for next dev version
+[[redirects]]
+  from = "/bonita/next/*"
+  to = "/bonita/1/:splat"
+  status = 200
+
 ########################################
 # Bonita Old Documentation redirects to Archives
 ########################################


### PR DESCRIPTION
`/next` will redirect to `/1` (aka the alpha version) without changing the URL. 
The main url is - and will remain - `/1`, because it allows us to ensure that the dev version is sorted correctly among other versions (at the end). So a user that go to the alpha version through the menu will have the URL `/1`. But at least, with this redirect, if we want to send a link to a client we can do it with `/next`, which is a bit better.

Tested locally. 