### PR TITLE
feat: generate netlify redirects for alias

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -49,3 +49,4 @@ asciidoc:
     - ./lib/tabs-block.js
 urls:
   html_extension_style: drop
+  redirect_facility: netlify

--- a/build-preview.bash
+++ b/build-preview.bash
@@ -37,7 +37,8 @@ function usage() {
   echo "      --single-branch-per-repo <boolean>      'true': only keep the latest declared branch for each component, 'false': use all branches. Defaults to 'false'"
   echo "      --site-url <url>                        Custom Url of the site preview. If set to 'DISABLED', remove the site.url from the Antora playbook. Defaults to the original url defined in the Antora playbook."
   echo "      --site-title <string>                   Title of the site preview. Use generated title if not set."
-  echo "      --type <string>                         If set to 'local', use html extension in urls to allow local file browsing"
+  echo "      --type <string>                         If set to 'local', use html extension in urls to allow local file browsing."
+  echo "                                              If set to 'netlify', use the configuration for the whole Netlify environment (for use with the dev server)."
   echo "      --use-all-repositories <boolean>        If set to 'true', use all sources repositories and branches defined in the production Antora playbook. Defaults to 'false'"
   echo "      --use-multi-repositories <boolean>      If set to 'true', use several repositories and branches passed with the --component-with-branches options. Defaults to 'false'"
 

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -38,15 +38,15 @@ function ensureArray(object) {
 const argv = require('minimist')(process.argv.slice(2), {
     string: 'branch', // as bonita branches match versions, branch could be considered as number, so this config prevents '7.10' from being converted into '7.1'
 });
-function getArgument(argv, argName, isMandatory) {
-    const value = argv[argName];
+function getArgument(args, argName, isMandatory) {
+    const value = args[argName];
     if (isMandatory && !value) {
         throw Error(`You must pass a '${argName}' argument`);
     }
     return value;
 }
-function getArgumentAsArray(argv, argName, isMandatory) {
-    return ensureArray(getArgument(argv, argName, isMandatory))
+function getArgumentAsArray(args, argName, isMandatory) {
+    return ensureArray(getArgument(args, argName, isMandatory))
 }
 
 // TODO rename options to use components instead of repositories


### PR DESCRIPTION
Aliases are now generating true http 301 instead of http 200 via http page; this
will be better for SEO.
Update the 'type' argument to enable it for preview.

closes #177 

### For testers

The `_redirects` file is created is the same folder as the site content and is created for the production build.
The preview defaults don't change: redirects are managed by dedicated html pages (for file browsing or http servers without redirect capacities).

Redirects generation for preview tested locally with 
- preview creation:  `./build-preview-dev.bash --component bonita --branch 2021.2 --local-sources true --type netlify`
- then run dev server: `npm run serve`

### Figures
**Note**: generated with `./build-preview-dev.bash --local-sources --force-production-navbar --use-all-repositories --type netlify` 

We currently have **606 redirects**: [_redirects.txt](https://github.com/bonitasoft/bonita-documentation-site/files/7504305/_redirects.txt)
- most are for Bonita 2021.2 and 2022.1 (mainly after the introduction of Antora modules)
- Bonita 7.9, 7.10, 7.11 have 4 each, 2021.1 has 6
- 6 are for labs (bici)

Files and size of the generated site
- static html page redirects: 5 600 elements, 642,0 MB
- netlify redirects: 4 995 elements, 641,7 MB (606 redirect html pages removed, _redirects file added)