### PR TITLE
feat: simplify netlify redirects for BCD

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -103,31 +103,31 @@ status = 200
 
 [[redirects]]
 from = "/bcd/"
-to = "/bcd/3.5/"
+to = "/bcd/latest/"
 
 [[redirects]]
 from = "/bcd/1.0/*"
-to = "/bcd/3.4/:splat"
+to = "/bcd/latest/:splat"
 
 [[redirects]]
 from = "/bcd/2.0/*"
-to = "/bcd/3.4/:splat"
+to = "/bcd/latest/:splat"
 
 [[redirects]]
 from = "/bcd/2.1/*"
-to = "/bcd/3.4/:splat"
+to = "/bcd/latest/:splat"
 
 [[redirects]]
 from = "/bcd/3.0/*"
-to = "/bcd/3.4/:splat"
+to = "/bcd/latest/:splat"
 
 [[redirects]]
 from = "/bcd/3.1/*"
-to = "/bcd/3.4/:splat"
+to = "/bcd/latest/:splat"
 
 [[redirects]]
 from = "/bcd/3.2/*"
-to = "/bcd/3.4/:splat"
+to = "/bcd/latest/:splat"
 
 [[redirects]]
 from = "/bcd/3.3/*"


### PR DESCRIPTION
Redirect all old versions and non version url to latest.
This reduces maintenance when releasing a new version.

### For reviewers

I didn't test locally as changes are only replacements, but it's probably worth testing it once 😸 