### PR TITLE
fix(redirect): bonita 'latest' url also uses alias redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,10 +13,13 @@
 ########################################
 # Bonita redirects
 ########################################
+# use http 302 as the Antora 3 does with https://docs.antora.org/antora/3.0/playbook/urls-latest-version-segment-strategy/
+# Comparing to http 200, the user doesn't have the 'latest' url in the browser navigation bar
+# but this ensures that other redirects (especially those generated from aliases) are considered when using the 'latest' url
 [[redirects]]
   from = "/bonita/latest/*"
   to = "/bonita/2021.2/:splat"
-  status = 200
+  status = 302
 
 [[redirects]]
   from = "/bonita/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -47,7 +47,7 @@
 # Bonita Community redirect to getting Started
 [[redirects]]
   from = "/bonita/*/_getting-started-tutorial"
-  to = "/bonita/latest/tutorial-overview"
+  to = "/bonita/latest/getting-started/getting-started-index"
 
 # Redirect for next dev version
 [[redirects]]
@@ -78,11 +78,11 @@ to = "/bonita/0/"
 # specific redirects for 6.x-7.2
 [[redirects]]
 from = "/6.x-7.2/install-tomcat-service-windows"
-to = "/bonita/latest/bonita-as-windows-service"
+to = "/bonita/latest/runtime/bonita-as-windows-service"
 
 [[redirects]]
 from = "/6.x-7.2/create-your-first-project-web-rest-api-and-maven"
-to = "/bonita/latest/rest-api-extensions"
+to = "/bonita/latest/api/rest-api-extension-archetype"
 
 # defaults redirects for 6.x-7.2
 # WARN: ensure specific redirects are defined before this one


### PR DESCRIPTION
The former redirect haven't worked anymore since the introduction of Antora modules and some page renames.
This is because we use HTTP 200 for latest redirect, in this case, Netlify behaves as a proxy and the redirects generated by aliases were not used. So we got 404 errors.

Fix the redirects for the old `_getting_started page`: there is no alias for the previously targeted page that has been renamed/moved
Update the redirects for bonita 6.x-7.2 specific pages to avoid extra hoop.


See also #278 

### Tests done locally

Build preview for netlify: `./build-preview-dev.bash --local-sources --type netlify  --component bonita --branch 2021.2`
Netlify environment simulation: `npm run serve`

- general latest urls: localhost:8080/bonita/latest/getting-started-index --> --> http://localhost:8080/bonita/2021.2/getting-started/getting-started-index
- /6.x-7.2/install-tomcat-service-windows --> http://localhost:8080/bonita/2021.2/runtime/bonita-as-windows-service
- /6.x-7.2/create-your-first-project-web-rest-api-and-maven --> http://localhost:8080/bonita/2021.2/api/rest-api-extensions
- localhost:8080/bonita/7.4/_getting-started-tutorial --> http://localhost:8080/bonita/2021.2/getting-started/getting-started-index

