### PR TITLE
chore(wf): no checkout for PR convention checks

### DIFF
--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -9,9 +9,6 @@ jobs:
   check-for-cc:
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: check-for-cc
         id: check-for-cc
         uses: agenthunt/conventional-commit-checker-action@v1.0.0


### PR DESCRIPTION
We are only checking the PR title and description so we don't need to checkout (we are not considering the repository code here).