### PR TITLE
chore: improve paths that trigger github workflows

### DIFF
--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -7,9 +7,9 @@ on:
     branches:
       - master
     paths:
-      - 'resources/*'
+      - 'resources/**/*'
       - 'antora-playbook.yml'
-      - '.github/actions/build-setup/*'
+      - '.github/actions/build-setup/**/*'
       - '.github/workflows/publish-pr-preview.yml'
 
 permissions:

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -15,9 +15,9 @@ on:
     branches:
       - master
     paths:
-      - 'resources/*'
+      - 'resources/**/*'
       - 'antora-playbook.yml'
-      - '.github/actions/build-setup/*'
+      - '.github/actions/build-setup/**/*'
       - '.github/workflows/publish-production.yml'
       - 'netlify.toml'
 


### PR DESCRIPTION
The previous path configuration were not trigger the workflows when changes occur in sub-folders.