### PR TITLE
feat(failure level): make the build fail on errors

### DIFF
--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
+      BONITA_BRANCH: '2021.2'
+      BCD_BRANCH: '3.5'
+      CLOUD_BRANCH: 'master'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -44,5 +47,5 @@ jobs:
           failOnError: true
           teardown: 'true'
           build: |
-            ./build-preview.bash --single- --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}" --single-branch-per-repo true
+            ./build-preview.bash --use-multi-repositories --component-with-branches bonita:"${{ env.BONITA_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
             ls -lh build/site

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -24,6 +24,8 @@ jobs:
       BONITA_BRANCH: '2021.2'
       BCD_BRANCH: '3.5'
       CLOUD_BRANCH: 'master'
+      LABS_BRANCH: 'master'
+      TOOLKIT_BRANCH: '1.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -47,5 +49,5 @@ jobs:
           failOnError: true
           teardown: 'true'
           build: |
-            ./build-preview.bash --use-multi-repositories --component-with-branches bonita:"${{ env.BONITA_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
+            ./build-preview.bash --use-multi-repositories --component-with-branches bonita:"${{ env.BONITA_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --component-with-branches labs:"${{ env.LABS_BRANCH }}" --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
             ls -lh build/site

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -13,6 +13,8 @@ runtime:
     format: pretty
     # set to info to get details from the Antora extensions
     level: info
+    # Antora exits with a non-zero exit code if an error is logged -> https://docs.antora.org/antora/latest/playbook/runtime-log-failure-level
+    failure_level: error
 
 content:
   # When adding a new url, add a new entry in generate-content-for-preview-antora-playbook.js to manage PR preview


### PR DESCRIPTION
The failure-level option make Antora exits with a non-zero code when a message is logged with a severity error or higher. 
This allow us to make the build fail when a user try to commit an error in the documentation (invalid xref...)