### PR TITLE
chore: Send slack notification when publish failed

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -68,3 +68,49 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         timeout-minutes: 10
+      - name: Send message to Slack channel
+        if: failure()
+        uses: slackapi/slack-github-action@v1.17.0
+        with:
+          channel-id: 'CCQGMR4ES'
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":red_circle:  Publish documentation in production failed. \n \n  @channel *We need someone* !"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "More details about the error <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}?check_suite_focus=true| here>"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "_C’est pas grave de faire des erreurs. Par contre il ne faut pas les merger!_ :imp:"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "plain_text",
+                      "text": "Author: Adrien L.",
+                      "emoji": true
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
* After enabled failedOnError antora attribute, we need a notification to know when the publish failed