### PR TITLE
chore: Teardown surge inactive

### DIFF
--- a/.github/workflows/teardown-inactive-surge-deployments.yml
+++ b/.github/workflows/teardown-inactive-surge-deployments.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Teardown surge deployement inactive than more 1 month
-        uses: adrianjost/actions-surge.sh-teardown
+        uses: adrianjost/actions-surge.sh-teardown@v1.0.3
         with:
           regex: '[1-9]+ month.? ago'
         env:

--- a/.github/workflows/teardown-inactive-surge-deployments.yml
+++ b/.github/workflows/teardown-inactive-surge-deployments.yml
@@ -1,0 +1,18 @@
+name: Teardown inactive site
+
+on:
+  schedule:
+    - cron: '0 3 * * 6'
+  workflow_dispatch:
+
+jobs:
+  teardown_inactive_deployement:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Teardown surge deployement inactive than more 1 month
+        uses: adrianjost/actions-surge.sh-teardown
+        with:
+          regex: '[1-9]+ month.? ago'
+        env:
+          SURGE_LOGIN: "hudson.mailer@bonitasoft.com"
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN_DOC }}


### PR DESCRIPTION
* Action is running each Saturday and kill inactive deployment for more than 1 month

Cover #315 