### PR TITLE
refactor(script): improve propagate-doc script

### DIFF
--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -32,8 +32,6 @@ jobs:
         run: |
           cd ./bonita-doc
           
-          # allow to keep our changes when merge=ours specified in .gitattributes
-          git config merge.ours.driver true
           # configure commiter information
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"

--- a/scripts/propagate_doc_upwards.bash
+++ b/scripts/propagate_doc_upwards.bash
@@ -39,6 +39,9 @@ merge() {
 log "Propagating documentation upwards"
 log "Configuration: NO_PUSH=${NO_PUSH}"
 
+# allow to keep our changes when merge=ours specified in .gitattributes
+git config merge.ours.driver true
+
 merge "7.11" "2021.1"
 merge "2021.1" "2021.2"
 merge "2021.2" "2022.1"


### PR DESCRIPTION
So that when run from local env (which is the case when resolving conflict manually)
the script contains the right default values:
`git config merge.ours.driver true`
