### PR TITLE
chore: publish pr preview and to production on package.json change

### DIFF
--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -7,11 +7,13 @@ on:
     branches:
       - master
     paths:
+      - '.github/actions/build-setup/**/*'
+      - '.github/workflows/publish-pr-preview.yml'
       - 'resources/**/*'
       - 'antora-playbook.yml'
       - 'build-preview.bash'
-      - '.github/actions/build-setup/**/*'
-      - '.github/workflows/publish-pr-preview.yml'
+      - 'package.json'
+      - 'package-lock.json'
 
 permissions:
   # surge-preview creates or updates PR comments about the deployment status

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -15,11 +15,13 @@ on:
     branches:
       - master
     paths:
-      - 'resources/**/*'
-      - 'antora-playbook.yml'
       - '.github/actions/build-setup/**/*'
       - '.github/workflows/publish-production.yml'
+      - 'resources/**/*'
+      - 'antora-playbook.yml'
       - 'netlify.toml'
+      - 'package.json'
+      - 'package-lock.json'
 
 permissions:
   # netlify: notify deployments


### PR DESCRIPTION
### Notes

We currently have a dependabot update issue
> Dependabot can't parse your package-lock.json
> Dependabot failed to update your dependencies because there was an error parsing the package-lock.json found at /package-lock.json.
> Dependabot encountered the following error:
> Dependabot::DependencyFileNotParseable

