### PR TITLE
chore: avoid several production deploys at the same time

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -1,4 +1,7 @@
 name: Publish production
+# Allow only one running and one pending instance of this workflow. See https://github.com/bonitasoft/bonita-documentation-site/issues/192
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
+concurrency: ${{ github.workflow }}
 
 on:
   repository_dispatch:


### PR DESCRIPTION
Allow only one running and one pending instance of this publishing workflow.
This reduces the usage of GitHub runners and useless deployments.

closes #192
tested with https://github.com/process-analytics/github-actions-playground/pull/91

### For reviewers

Please check the defined concurrency is well configured. Based on my understanding of the documentation, using the name of the workflow is enough. We don't care of the git ref sha and other information.
We only want to keep the latest pending workflow in the queue.