### PR TITLE
chore: only publish the PR preview for repository members

### DIFF
--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -20,7 +20,24 @@ permissions:
   pull-requests: write
 
 jobs:
+  # inspired from https://github.community/t/how-can-i-test-if-secrets-are-available-in-an-action/17911/9
+  check_secrets:
+    runs-on: ubuntu-20.04
+    outputs:
+      is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
+    steps:
+      - name: Compute secrets availability
+        id: secret_availability
+        env:
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN_DOC }}
+        run: |
+          echo "is_SURGE_TOKEN_set: ${{ env.SURGE_TOKEN != '' }}"
+          echo "::set-output name=is_SURGE_TOKEN_set::${{ env.SURGE_TOKEN != '' }}"
+
   build_preview:
+    needs: [check_secrets]
+    # Only build preview for member of the repository
+    if: needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
     runs-on: ubuntu-20.04
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
The surge secrets is not available when the PR is created from a fork repository or by Dependabot.
The lack of secrets was generating an error when attempting to deploy. So, detect when the secrets
are available and only deploy in this case.

covers #361 

### Notes

The configuration is taken from the bonita-doc repository
We have a lot of duplication across repository, I will investigate what can be done to reduce it as part of #361 and #239