### PR TITLE
chore: automate the ui bundle update

### DIFF
--- a/.github/workflows/new_theme_bundle.yml
+++ b/.github/workflows/new_theme_bundle.yml
@@ -1,0 +1,39 @@
+name: New theme bundle
+
+on:
+  repository_dispatch:
+    types: [new_theme_bundle]
+
+env:
+  release_name: ${{ github.event.client_payload.release }}
+  release_notes_url: ${{ github.event.client_payload.release_notes_url }}
+  bundle_file: ${{ github.event.client_payload.bundle_file }}
+  bundle_url: ${{ github.event.client_payload.bundle_url }}
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Perl environment
+        uses: shogo82148/actions-setup-perl@v1.15.3
+
+      - name: Update theme bundle in Antora playbook
+        run: |
+          echo "bundle_url=$bundle_url"
+          perl -007 -i -pe 's?.*ui:.*\n.*bundle:.*\n.*url:.*?ui:\n  bundle:\n    url: '$bundle_url'?' antora-playbook.yml
+          cat antora-playbook.yml    
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "feat(theme_bundle): update theme bundle in Antora playbook"
+          branch: "feat/update_theme_${{ env.release_name }}"
+          delete-branch: true
+          title: "feat(theme_bundle): new theme bundle ${{ env.bundle_file }}"
+          body: "- Update bundle theme with ${{ env.bundle_file }}\n Release notes: ${{ env.release_notes_url }}"

--- a/.github/workflows/update-theme-bundle.yml
+++ b/.github/workflows/update-theme-bundle.yml
@@ -1,4 +1,4 @@
-name: New theme bundle
+name: Update theme bundle
 
 on:
   repository_dispatch:
@@ -35,5 +35,5 @@ jobs:
           commit-message: "feat(theme_bundle): update theme bundle in Antora playbook"
           branch: "feat/update_theme_${{ env.release_name }}"
           delete-branch: true
-          title: "feat(theme_bundle): new theme bundle ${{ env.bundle_file }}"
+          title: "feat(theme): update theme bundle to ${{ env.release_name }}"
           body: "- Update bundle theme with ${{ env.bundle_file }}\n Release notes: ${{ env.release_notes_url }}"


### PR DESCRIPTION
Add a new workflow which:
  - Is launched by a 'new_theme_bundle' Repository Dispatch event
  - Update the Antora playbook with the new theme bundle url
  - Create the PR

Covers (doc-site part) [Find a way to not be forced to store the Antora UI bundle in the repository](https://github.com/bonitasoft/bonita-documentation-site/issues/47)