### PR TITLE
chore: drop bonita 7.11 content propagation

### DIFF
--- a/scripts/propagate_doc_upwards.bash
+++ b/scripts/propagate_doc_upwards.bash
@@ -42,7 +42,6 @@ log "Configuration: NO_PUSH=${NO_PUSH}"
 # allow to keep our changes when merge=ours specified in .gitattributes
 git config merge.ours.driver true
 
-merge "7.11" "2021.1"
 merge "2021.1" "2021.2"
 merge "2021.2" "2022.1"
 merge "2022.1" "2022.2"


### PR DESCRIPTION
7.11 is now out of support, so the branch won't be updated anymore.
So no need to propagate changes to branches of next versions.