### PR TITLE
chore: remove duplication in surge preview workflows

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -1,8 +1,9 @@
 name: 'Build and publish PR preview on surge.sh'
 description: 'Based on the surge-preview, hides the processing logic'
 
+# TODO document inputs description
 inputs:
-  gh-token:
+  github-token:
     description: ''
     required: true
   surge-token:

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -37,10 +37,7 @@ runs:
     - name: Build Preview
       if: github.event.action != 'closed'
       shell: bash
-      run: >
-        ${{ inputs.build-preview-command }}
-        --pr "${{ github.event.pull_request.number }}"
-        --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+      run: ${{ inputs.build-preview-command }} --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: Publish preview
       uses: afc163/surge-preview@v1
       if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -32,7 +32,6 @@ runs:
         repository: 'bonitasoft/bonita-documentation-site'
         ref: ${{ inputs.doc-site-branch }}
     - name: Build Setup
-      # TODO review path
       uses: ./.github/actions/build-setup
       if: github.event.action != 'closed'
     - name: Build Preview

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'A surge token to manage the deployment'
     required: true
   build-preview-command:
-    description: 'The documentation 'build-preview' command to build the preview'
+    description: 'The documentation `build-preview` command to build the preview'
     required: true
   # needed by content repository (default master) and here (computed automagically)
   doc-site-branch:

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -1,20 +1,19 @@
 name: 'Build and publish PR preview on surge.sh'
 description: 'Based on the surge-preview, hides the processing logic'
 
-# TODO document inputs description
 inputs:
   github-token:
-    description: ''
+    description: 'A token with `pull-requests: write` to let the surge-preview action create comments on pull requests'
     required: true
   surge-token:
-    description: ''
+    description: 'A surge token to manage the deployment'
     required: true
   build-preview-command:
-    description: ''
+    description: 'The documentation 'build-preview' command to build the preview'
     required: true
   # needed by content repository (default master) and here (computed automagically)
   doc-site-branch:
-    description: ''
+    description: 'The branch of the `bonita-documentation-site` used to build the site preview'
     required: false
     default: 'master'
 

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -11,8 +11,11 @@ inputs:
   build-preview-command:
     description: ''
     required: true
-  # TODO branch of doc-site
-  #needed by content repository (default master) and here (computed automagically)
+  # needed by content repository (default master) and here (computed automagically)
+  doc-site-branch:
+    description: ''
+    required: false
+    default: 'master'
 
 runs:
   using: "composite"
@@ -21,11 +24,14 @@ runs:
       id: surge-preview-tools
       with:
         surge-token: ${{ inputs.surge-token }}
-    # todo repository name
     - name: Checkout
       uses: actions/checkout@v3
       if: github.event.action != 'closed'
+      with:
+        repository: 'bonitasoft/bonita-documentation-site'
+        ref: ${{ inputs.doc-site-branch }}
     - name: Build Setup
+      # TODO review path
       uses: ./.github/actions/build-setup
       if: github.event.action != 'closed'
     - name: Build Preview

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -1,0 +1,48 @@
+name: 'Build and publish PR preview on surge.sh'
+description: 'Based on the surge-preview, hides the processing logic'
+
+inputs:
+  gh-token:
+    description: ''
+    required: true
+  surge-token:
+    description: ''
+    required: true
+  build-preview-command:
+    description: ''
+    required: true
+  # TODO branch of doc-site
+  #needed by content repository (default master) and here (computed automagically)
+
+runs:
+  using: "composite"
+  steps:
+    - uses: process-analytics/github-actions-playground/.github/actions/surge-preview-tools/@master
+      id: surge-preview-tools
+      with:
+        surge-token: ${{ inputs.surge-token }}
+    # todo repository name
+    - name: Checkout
+      uses: actions/checkout@v3
+      if: github.event.action != 'closed'
+    - name: Build Setup
+      uses: ./.github/actions/build-setup
+      if: github.event.action != 'closed'
+    - name: Build Preview
+      if: github.event.action != 'closed'
+      shell: bash
+      run: >
+        ${{ inputs.build-preview-command }}
+        --pr "${{ github.event.pull_request.number }}"
+        --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+    - name: Publish preview
+      uses: afc163/surge-preview@v1
+      if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
+      with:
+        surge_token: ${{ inputs.surge-token }}
+        github_token: ${{ inputs.github-token }}
+        dist: build/site
+        failOnError: true
+        teardown: true
+        build: |
+          ls -lh build/site

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -21,7 +21,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: process-analytics/github-actions-playground/.github/actions/surge-preview-tools/@master
+    - uses: bonitasoft/actions/packages/surge-preview-tools@v1.2.0
       id: surge-preview-tools
       with:
         surge-token: ${{ inputs.surge-token }}

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
         cache: 'npm'

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -52,7 +52,7 @@ jobs:
           --component-with-branches labs:"${{ env.LABS_BRANCH }}"
           --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
           --pr "${{ github.event.pull_request.number }}"
-          --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+          --site-url "https://${{ steps.surge-preview-tools.outputs.preview-url }}"
 
       # - name: Compute environment variables
       #   if: github.event.action != 'closed'

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -22,6 +22,8 @@ permissions:
 jobs:
   build_preview:
     runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: write # surge-preview write PR comments
     env:
       BONITA_BRANCH: '2021.2'
       BCD_BRANCH: '3.5'

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -32,9 +32,7 @@ jobs:
       - name: Compute environment variables
         run: |
           echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
-      # access to the local action
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3 # access to the local action
       - name: Build and publish PR preview
         uses: ./.github/actions/build-and-publish-pr-preview
         with:

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -41,11 +41,13 @@ jobs:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           doc-site-branch: ${{ env.BRANCH_NAME }}
-          build-preview-command: >
+          # '>' Replace newlines with spaces (folded)
+          # '-' No newline at end (strip)
+          # TODO restore indentation
+          build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
             --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"
             --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
             --component-with-branches labs:"${{ env.LABS_BRANCH }}"
             --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
-# end

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -48,3 +48,4 @@ jobs:
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
             --component-with-branches labs:"${{ env.LABS_BRANCH }}"
             --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
+# end

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -30,7 +30,7 @@ jobs:
       LABS_BRANCH: "master"
       TOOLKIT_BRANCH: "1.0"
     steps:
-      - uses: process-analytics/github-actions-playground/.github/actions/surge-preview-tools/@main
+      - uses: process-analytics/github-actions-playground/.github/actions/surge-preview-tools/@master
         id: surge-preview-tools
         with:
           surge-token: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -43,7 +43,6 @@ jobs:
           doc-site-branch: ${{ env.BRANCH_NAME }}
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
-          # TODO restore indentation
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
             --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -49,7 +49,7 @@ jobs:
           --component-with-branches labs:"${{ env.LABS_BRANCH }}"
           --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
           --pr "${{ github.event.pull_request.number }}"
-          --site-url "https://${{ steps.surge-preview-tools.outputs.preview-url }}"
+          --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
       - name: Publish preview
         uses: afc163/surge-preview@v1
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -7,67 +7,68 @@ on:
     branches:
       - master
     paths:
-      - '.github/actions/build-setup/**/*'
-      - '.github/workflows/publish-pr-preview.yml'
-      - 'resources/**/*'
-      - 'antora-playbook.yml'
-      - 'build-preview.bash'
-      - 'package.json'
-      - 'package-lock.json'
+      - ".github/actions/build-setup/**/*"
+      - ".github/workflows/publish-pr-preview.yml"
+      - "resources/**/*"
+      - "antora-playbook.yml"
+      - "build-preview.bash"
+      - "package.json"
+      - "package-lock.json"
 
 permissions:
   # surge-preview creates or updates PR comments about the deployment status
   pull-requests: write
 
 jobs:
-  # inspired from https://github.community/t/how-can-i-test-if-secrets-are-available-in-an-action/17911/9
-  check_secrets:
-    runs-on: ubuntu-20.04
-    outputs:
-      is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
-    steps:
-      - name: Compute secrets availability
-        id: secret_availability
-        env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN_DOC }}
-        run: |
-          echo "is_SURGE_TOKEN_set: ${{ env.SURGE_TOKEN != '' }}"
-          echo "::set-output name=is_SURGE_TOKEN_set::${{ env.SURGE_TOKEN != '' }}"
-
   build_preview:
-    needs: [check_secrets]
-    # Only build preview for member of the repository
-    if: needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
     runs-on: ubuntu-20.04
     env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      BONITA_BRANCH: '2021.2'
-      BCD_BRANCH: '3.5'
-      CLOUD_BRANCH: 'master'
-      LABS_BRANCH: 'master'
-      TOOLKIT_BRANCH: '1.0'
+      #PR_NUMBER: ${{ github.event.pull_request.number }}
+      BONITA_BRANCH: "2021.2"
+      BCD_BRANCH: "3.5"
+      CLOUD_BRANCH: "master"
+      LABS_BRANCH: "master"
+      TOOLKIT_BRANCH: "1.0"
     steps:
+      - uses: process-analytics/github-actions-playground/.github/actions/surge-preview-tools/@main
+        id: surge-preview-tools
+        with:
+          surge-token: ${{ secrets.SURGE_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v3
         if: github.event.action != 'closed'
       - name: Build Setup
         uses: ./.github/actions/build-setup
         if: github.event.action != 'closed'
-      - name: Compute environment variables
+      - name: Build Preview
         if: github.event.action != 'closed'
-        run: |
-          echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
-          # the surge-preview action generates https://{{repository.owner}}-{{repository.name}}-{{job.name}}-pr-{{pr.number}}.surge.sh
-          repo_owner_and_name=$(echo "${{github.repository}}" | sed 's/\//-/g')
-          echo PREVIEW_URL=https://$repo_owner_and_name-"${{github.job}}"-pr-$PR_NUMBER.surge.sh >> $GITHUB_ENV
+        # env:
+        # PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: >
+          ./build-preview.bash --use-multi-repositories
+          --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"
+          --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
+          --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
+          --component-with-branches labs:"${{ env.LABS_BRANCH }}"
+          --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
+          --pr "${{ github.event.pull_request.number }}"
+          --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+
+      # - name: Compute environment variables
+      #   if: github.event.action != 'closed'
+      #   run: |
+      #     echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
+      #     # the surge-preview action generates https://{{repository.owner}}-{{repository.name}}-{{job.name}}-pr-{{pr.number}}.surge.sh
+      #     repo_owner_and_name=$(echo "${{github.repository}}" | sed 's/\//-/g')
+      #     echo PREVIEW_URL=https://$repo_owner_and_name-"${{github.job}}"-pr-$PR_NUMBER.surge.sh >> $GITHUB_ENV
       - name: Publish preview
         uses: afc163/surge-preview@v1
+        if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
         with:
           surge_token: ${{ secrets.SURGE_TOKEN_DOC }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           dist: build/site
           failOnError: true
-          teardown: 'true'
+          teardown: true
           build: |
-            ./build-preview.bash --use-multi-repositories --component-with-branches bonita:"${{ env.BONITA_BRANCH }}" --component-with-branches bcd:"${{ env.BCD_BRANCH }}" --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}" --component-with-branches labs:"${{ env.LABS_BRANCH }}" --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
             ls -lh build/site

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -29,35 +29,19 @@ jobs:
       LABS_BRANCH: 'master'
       TOOLKIT_BRANCH: '1.0'
     steps:
-      - uses: process-analytics/github-actions-playground/.github/actions/surge-preview-tools/@master
-        id: surge-preview-tools
+      - name: Compute environment variables
+        run: |
+          echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
+      - name: Build and publish PR preview
+        uses: process-analytics/github-actions-playground/.github/actions/surge-preview-tools/@${{ env.BRANCH_NAME }}
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
-      - name: Checkout
-        uses: actions/checkout@v3
-        if: github.event.action != 'closed'
-      - name: Build Setup
-        uses: ./.github/actions/build-setup
-        if: github.event.action != 'closed'
-      - name: Build Preview
-        if: github.event.action != 'closed'
-        run: >
-          ./build-preview.bash --use-multi-repositories
-          --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"
-          --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
-          --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
-          --component-with-branches labs:"${{ env.LABS_BRANCH }}"
-          --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
-          --pr "${{ github.event.pull_request.number }}"
-          --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
-      - name: Publish preview
-        uses: afc163/surge-preview@v1
-        if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
-        with:
-          surge_token: ${{ secrets.SURGE_TOKEN_DOC }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: build/site
-          failOnError: true
-          teardown: true
-          build: |
-            ls -lh build/site
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          doc-site-branch: ${{ env.BRANCH_NAME }}
+          build-preview-command: >
+            ./build-preview.bash --use-multi-repositories
+              --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"
+              --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
+              --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
+              --component-with-branches labs:"${{ env.LABS_BRANCH }}"
+              --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -32,8 +32,11 @@ jobs:
       - name: Compute environment variables
         run: |
           echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
+      # access to the local action
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Build and publish PR preview
-        uses: process-analytics/github-actions-playground/.github/actions/surge-preview-tools/@${{ env.BRANCH_NAME }}
+        uses: ./.github/actions/build-and-publish-pr-preview
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -43,8 +43,8 @@ jobs:
           doc-site-branch: ${{ env.BRANCH_NAME }}
           build-preview-command: >
             ./build-preview.bash --use-multi-repositories
-              --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"
-              --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
-              --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
-              --component-with-branches labs:"${{ env.LABS_BRANCH }}"
-              --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
+            --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"
+            --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
+            --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
+            --component-with-branches labs:"${{ env.LABS_BRANCH }}"
+            --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -15,15 +15,11 @@ on:
       - 'package.json'
       - 'package-lock.json'
 
-permissions:
-  # surge-preview creates or updates PR comments about the deployment status
-  pull-requests: write
-
 jobs:
   build_preview:
     runs-on: ubuntu-20.04
     permissions:
-      pull-requests: write # surge-preview write PR comments
+      pull-requests: write # surge-preview creates or updates PR comments about the deployment status
     env:
       BONITA_BRANCH: '2021.2'
       BCD_BRANCH: '3.5'

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: process-analytics/github-actions-playground/.github/actions/surge-preview-tools/@master
         id: surge-preview-tools
         with:
-          surge-token: ${{ secrets.SURGE_TOKEN }}
+          surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
       - name: Checkout
         uses: actions/checkout@v3
         if: github.event.action != 'closed'

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -23,7 +23,6 @@ jobs:
   build_preview:
     runs-on: ubuntu-20.04
     env:
-      #PR_NUMBER: ${{ github.event.pull_request.number }}
       BONITA_BRANCH: "2021.2"
       BCD_BRANCH: "3.5"
       CLOUD_BRANCH: "master"
@@ -42,8 +41,6 @@ jobs:
         if: github.event.action != 'closed'
       - name: Build Preview
         if: github.event.action != 'closed'
-        # env:
-        # PR_NUMBER: ${{ github.event.pull_request.number }}
         run: >
           ./build-preview.bash --use-multi-repositories
           --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"
@@ -53,14 +50,6 @@ jobs:
           --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
           --pr "${{ github.event.pull_request.number }}"
           --site-url "https://${{ steps.surge-preview-tools.outputs.preview-url }}"
-
-      # - name: Compute environment variables
-      #   if: github.event.action != 'closed'
-      #   run: |
-      #     echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
-      #     # the surge-preview action generates https://{{repository.owner}}-{{repository.name}}-{{job.name}}-pr-{{pr.number}}.surge.sh
-      #     repo_owner_and_name=$(echo "${{github.repository}}" | sed 's/\//-/g')
-      #     echo PREVIEW_URL=https://$repo_owner_and_name-"${{github.job}}"-pr-$PR_NUMBER.surge.sh >> $GITHUB_ENV
       - name: Publish preview
         uses: afc163/surge-preview@v1
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -7,13 +7,13 @@ on:
     branches:
       - master
     paths:
-      - ".github/actions/build-setup/**/*"
-      - ".github/workflows/publish-pr-preview.yml"
-      - "resources/**/*"
-      - "antora-playbook.yml"
-      - "build-preview.bash"
-      - "package.json"
-      - "package-lock.json"
+      - '.github/actions/build-setup/**/*'
+      - '.github/workflows/publish-pr-preview.yml'
+      - 'resources/**/*'
+      - 'antora-playbook.yml'
+      - 'build-preview.bash'
+      - 'package.json'
+      - 'package-lock.json'
 
 permissions:
   # surge-preview creates or updates PR comments about the deployment status
@@ -23,11 +23,11 @@ jobs:
   build_preview:
     runs-on: ubuntu-20.04
     env:
-      BONITA_BRANCH: "2021.2"
-      BCD_BRANCH: "3.5"
-      CLOUD_BRANCH: "master"
-      LABS_BRANCH: "master"
-      TOOLKIT_BRANCH: "1.0"
+      BONITA_BRANCH: '2021.2'
+      BCD_BRANCH: '3.5'
+      CLOUD_BRANCH: 'master'
+      LABS_BRANCH: 'master'
+      TOOLKIT_BRANCH: '1.0'
     steps:
       - uses: process-analytics/github-actions-playground/.github/actions/surge-preview-tools/@master
         id: surge-preview-tools


### PR DESCRIPTION
Introduce a dedicated action to build and publish the PR preview on surge
  - it should be reused in documentation content repositories: see https://github.com/bonitasoft/bonita-doc/pull/2071
  - it relies on an additional action from the `bonitasoft/actions` repository: https://github.com/bonitasoft/actions/releases/tag/v1.2.0. It provides more context for the surge-preview action: the preview url, know if the surge preview can be run (in particular during PR closed to prevent error when the surge domain doesn't exist)

covers #270 #361