### PR TITLE
feat(start_page): New start-page parameter for build-preview script

### DIFF
--- a/build-preview.bash
+++ b/build-preview.bash
@@ -40,7 +40,7 @@ function usage() {
   echo "      --site-url <url>                        Custom Url of the site preview. If set to 'DISABLED', remove the site.url from the Antora playbook. Defaults to the original url defined in the Antora playbook."
   echo "      --site-title <string>                   Title of the site preview. Use generated title if not set."
   echo "      --start-page <string>                   Start page to be used for the site preview. Syntax is: 'version@component:module:file-coordinate-of-page.adoc', for instance '3.4@bcd::release_notes.adoc' or 'cloud::index.adoc'."
-  echo "                                              Use default (latest version of the bonita index page) if not set."
+  echo "                                              If not set, use '<component-name>::index.adoc' if the option is set, otherwise use default (latest version of the bonita index page)."
   echo "      --type <string>                         If set to 'local', use html extension in urls to allow local file browsing."
   echo "                                              If set to 'netlify', use the configuration for the whole Netlify environment (for use with the dev server)."
   echo "      --use-all-repositories <boolean>        If set to 'true', use all sources repositories and branches defined in the production Antora playbook. Defaults to 'false'"

--- a/build-preview.bash
+++ b/build-preview.bash
@@ -39,7 +39,7 @@ function usage() {
   echo "      --single-branch-per-repo <boolean>      'true': only keep the latest declared branch for each component, 'false': use all branches. Defaults to 'false'"
   echo "      --site-url <url>                        Custom Url of the site preview. If set to 'DISABLED', remove the site.url from the Antora playbook. Defaults to the original url defined in the Antora playbook."
   echo "      --site-title <string>                   Title of the site preview. Use generated title if not set."
-  echo "      --start-page <string>                   Start page to be used for the site preview. Syntax is: 'version@component:module:file-coordinate-of-page.adoc', for instance '3.4@bcd::release_notes.adoc'."
+  echo "      --start-page <string>                   Start page to be used for the site preview. Syntax is: 'version@component:module:file-coordinate-of-page.adoc', for instance '3.4@bcd::release_notes.adoc' or 'cloud::index.adoc'."
   echo "                                              Use default (bonita index.adoc) if not set."
   echo "      --type <string>                         If set to 'local', use html extension in urls to allow local file browsing."
   echo "                                              If set to 'netlify', use the configuration for the whole Netlify environment (for use with the dev server)."

--- a/build-preview.bash
+++ b/build-preview.bash
@@ -39,6 +39,8 @@ function usage() {
   echo "      --single-branch-per-repo <boolean>      'true': only keep the latest declared branch for each component, 'false': use all branches. Defaults to 'false'"
   echo "      --site-url <url>                        Custom Url of the site preview. If set to 'DISABLED', remove the site.url from the Antora playbook. Defaults to the original url defined in the Antora playbook."
   echo "      --site-title <string>                   Title of the site preview. Use generated title if not set."
+  echo "      --start-page <string>                   Start page to be used for the site preview. Syntax is: 'version@component:module:file-coordinate-of-page.adoc', for instance '3.4@bcd::release_notes.adoc'."
+  echo "                                              Use default (bonita index.adoc) if not set."
   echo "      --type <string>                         If set to 'local', use html extension in urls to allow local file browsing."
   echo "                                              If set to 'netlify', use the configuration for the whole Netlify environment (for use with the dev server)."
   echo "      --use-all-repositories <boolean>        If set to 'true', use all sources repositories and branches defined in the production Antora playbook. Defaults to 'false'"

--- a/build-preview.bash
+++ b/build-preview.bash
@@ -40,7 +40,7 @@ function usage() {
   echo "      --site-url <url>                        Custom Url of the site preview. If set to 'DISABLED', remove the site.url from the Antora playbook. Defaults to the original url defined in the Antora playbook."
   echo "      --site-title <string>                   Title of the site preview. Use generated title if not set."
   echo "      --start-page <string>                   Start page to be used for the site preview. Syntax is: 'version@component:module:file-coordinate-of-page.adoc', for instance '3.4@bcd::release_notes.adoc' or 'cloud::index.adoc'."
-  echo "                                              Use default (bonita index.adoc) if not set."
+  echo "                                              Use default (latest version of the bonita index page) if not set."
   echo "      --type <string>                         If set to 'local', use html extension in urls to allow local file browsing."
   echo "                                              If set to 'netlify', use the configuration for the whole Netlify environment (for use with the dev server)."
   echo "      --use-all-repositories <boolean>        If set to 'true', use all sources repositories and branches defined in the production Antora playbook. Defaults to 'false'"

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -58,9 +58,11 @@ const useTestSources = getArgument(argv, 'use-test-sources', false);
 const siteUrl = getArgument(argv, 'site-url', false)
 const prNumber = getArgument(argv, 'pr', false)
 const siteTitle = getArgument(argv, 'site-title', false)
+const startPage = getArgument(argv, 'start-page', false);
 console.info(`PR: ${prNumber}`);
 console.info(`Site Url: ${siteUrl}`);
 console.info(`Site Title: ${siteTitle}`);
+console.info(`Start Page: ${startPage}`);
 
 const doc = yaml.load(fs.readFileSync('antora-playbook.yml', 'utf8'));
 console.info('Antora Playbook source file loaded');
@@ -135,6 +137,10 @@ else {
     doc.site.start_page = `${componentName}::index.adoc`;
 }
 
+// override the start page if startPage is given as parameter
+if (startPage) {
+    doc.site.start_page = startPage;
+}
 
 // use local sources for the documentation content repositories
 const useLocalSources = getArgument(argv, 'local-sources', false)


### PR DESCRIPTION
Added new 'start-page' optional parameter to build-preview.bash
See https://docs.antora.org/antora/latest/playbook/site-start-page/ for details

closes #372 