### PR TITLE
chore(surge-preview-action): use the latest version of the surge-preview-tools action

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: bonitasoft/actions/packages/surge-preview-tools@v1.2.0
+    - uses: bonitasoft/actions/packages/surge-preview-tools@v1
       id: surge-preview-tools
       with:
         surge-token: ${{ inputs.surge-token }}

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
     paths:
+      - '.github/actions/build-and-publish-pr-preview/**/*'
       - '.github/actions/build-setup/**/*'
       - '.github/workflows/publish-pr-preview.yml'
       - 'resources/**/*'


### PR DESCRIPTION
The shared action also used in documentation content repository (see #270) now uses the new generic v1 tag of the `surge-preview-tools` action. We will then get the latest compatible changes automatically without having to update the version manually.
Latest changes in this action, see https://github.com/bonitasoft/actions/releases/tag/v1.3.0
> improve behavior when the surge token is not set (remove extra annoying warning logs that are not relevant)

In addition, the "pr preview" workflow is now also run when 'build-and-publish-pr-preview' changes.