### PR TITLE
ci: Separate preview and build in two worflows

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: 'master'
   publish-preview:
-    description: 'The branch of the `bonita-documentation-site` used to build the site preview'
+    description: 'Allow to publish to surge only if this input is true'
     type: boolean
     required: false
     default: 'true'

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Build Site without error check
       if: github.event.action != 'closed' && inputs.component-name != ''
       shell: bash
-      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error true
+      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: Build Site
       if: github.event.action != 'closed' && inputs.component-name == ''
       shell: bash
@@ -53,7 +53,7 @@ runs:
         du --max-depth=2 -h
     - name: Publish preview
       uses: afc163/surge-preview@v1
-      if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true' && inputs.publish-preview == 'true'
+      if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
       with:
         surge_token: ${{ inputs.surge-token }}
         github_token: ${{ inputs.github-token }}

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -37,11 +37,11 @@ runs:
       uses: ./.github/actions/build-setup
       if: github.event.action != 'closed'
     - name: Build Site without error check
-      if: github.event.action != 'closed' && input.component-name != ''
+      if: github.event.action != 'closed' && inputs.component-name != ''
       shell: bash
-      run: ./build-preview.bash --component ${{input.component-name}} --branch ${{ github.head_ref }} --ignore-error true"
+      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error true"
     - name: Build Site
-      if: github.event.action != 'closed' && input.component-name == ''
+      if: github.event.action != 'closed' && inputs.component-name == ''
       shell: bash
       run: ${{ inputs.build-preview-command }} --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: Publish preview

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Build Site without error check
       if: github.event.action != 'closed' && inputs.component-name != ''
       shell: bash
-      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error true"
+      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error true
     - name: Build Site
       if: github.event.action != 'closed' && inputs.component-name == ''
       shell: bash

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -10,17 +10,15 @@ inputs:
     required: true
   build-preview-command:
     description: 'The documentation `build-preview` command to build the preview'
-    required: true
+    required: false
   # needed by content repository (default master) and here (computed automagically)
   doc-site-branch:
     description: 'The branch of the `bonita-documentation-site` used to build the site preview'
     required: false
     default: 'master'
-  publish-preview:
-    description: 'Allow to publish to surge only if this input is true'
-    type: boolean
+  component-name:
     required: false
-    default: 'true'
+    default: ''
 
 runs:
   using: "composite"
@@ -38,8 +36,12 @@ runs:
     - name: Build Setup
       uses: ./.github/actions/build-setup
       if: github.event.action != 'closed'
+    - name: Build Site without error check
+      if: github.event.action != 'closed' && input.component-name != ''
+      shell: bash
+      run: ./build-preview.bash --component ${{input.component-name}} --branch ${{ github.head_ref }} --ignore-error true"
     - name: Build Site
-      if: github.event.action != 'closed'
+      if: github.event.action != 'closed' && input.component-name == ''
       shell: bash
       run: ${{ inputs.build-preview-command }} --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: Publish preview

--- a/.github/actions/build-pr-site/action.yml
+++ b/.github/actions/build-pr-site/action.yml
@@ -2,9 +2,6 @@ name: 'Build site from PR'
 description: 'Based on the surge-preview, hides the processing logic'
 
 inputs:
-  github-token:
-    description: 'A token with `pull-requests: write` to let the surge-preview action create comments on pull requests'
-    required: true
   build-preview-command:
     description: 'The documentation `build-preview` command to build the preview'
     required: true

--- a/.github/actions/build-pr-site/action.yml
+++ b/.github/actions/build-pr-site/action.yml
@@ -1,5 +1,5 @@
 name: 'Build site from PR'
-description: 'Based on the surge-preview, hides the processing logic'
+description: 'Build site from a PR to check if all xref references are valid'
 
 inputs:
   build-preview-command:

--- a/.github/actions/build-pr-site/action.yml
+++ b/.github/actions/build-pr-site/action.yml
@@ -1,12 +1,9 @@
-name: 'Build and publish PR preview on surge.sh'
+name: 'Build site from PR'
 description: 'Based on the surge-preview, hides the processing logic'
 
 inputs:
   github-token:
     description: 'A token with `pull-requests: write` to let the surge-preview action create comments on pull requests'
-    required: true
-  surge-token:
-    description: 'A surge token to manage the deployment'
     required: true
   build-preview-command:
     description: 'The documentation `build-preview` command to build the preview'
@@ -16,19 +13,10 @@ inputs:
     description: 'The branch of the `bonita-documentation-site` used to build the site preview'
     required: false
     default: 'master'
-  publish-preview:
-    description: 'The branch of the `bonita-documentation-site` used to build the site preview'
-    type: boolean
-    required: false
-    default: 'true'
 
 runs:
   using: "composite"
   steps:
-    - uses: bonitasoft/actions/packages/surge-preview-tools@v1
-      id: surge-preview-tools
-      with:
-        surge-token: ${{ inputs.surge-token }}
     - name: Checkout
       uses: actions/checkout@v3
       if: github.event.action != 'closed'
@@ -41,15 +29,4 @@ runs:
     - name: Build Site
       if: github.event.action != 'closed'
       shell: bash
-      run: ${{ inputs.build-preview-command }} --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
-    - name: Publish preview
-      uses: afc163/surge-preview@v1
-      if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true' && inputs.publish-preview == 'true'
-      with:
-        surge_token: ${{ inputs.surge-token }}
-        github_token: ${{ inputs.github-token }}
-        dist: build/site
-        failOnError: true
-        teardown: true
-        build: |
-          ls -lh build/site
+      run: ${{ inputs.build-preview-command }} --pr "${{ github.event.pull_request.number }}"

--- a/.github/workflows/build-all-site.yml
+++ b/.github/workflows/build-all-site.yml
@@ -19,8 +19,6 @@ on:
 jobs:
   build_site:
     runs-on: ubuntu-20.04
-    permissions:
-      pull-requests: write # surge-preview creates or updates PR comments about the deployment status
     env:
       BONITA_BRANCH: '2021.2,2022.2'
       BCD_BRANCH: '3.5'
@@ -28,15 +26,12 @@ jobs:
       LABS_BRANCH: 'master'
       TOOLKIT_BRANCH: '1.0'
     steps:
-      - name: Compute environment variables
-        run: |
-          echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
       - uses: actions/checkout@v3 # access to the local action
-      - name: Build and publish PR preview
+      - name: Build PR site
         uses: ./.github/actions/build-pr-site
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          doc-site-branch: ${{ env.BRANCH_NAME }}
+          doc-site-branch: ${{ github.head_ref }}
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-

--- a/.github/workflows/build-all-site.yml
+++ b/.github/workflows/build-all-site.yml
@@ -29,8 +29,7 @@ jobs:
       - name: Build PR site
         uses: ./.github/actions/build-pr-site
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          doc-site-branch:
+          doc-site-branch: ${{ github.head_ref }}
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-

--- a/.github/workflows/build-all-site.yml
+++ b/.github/workflows/build-all-site.yml
@@ -1,4 +1,4 @@
-name: Build documentation site without publish preview
+name: PR Build documentation site
 on:
   pull_request:
     # To manage 'surge-preview' action teardown, add default event types + closed event type
@@ -36,7 +36,8 @@ jobs:
           # '-' No newline at end (strip)
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
-            --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"            
+            --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"
+            --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
             --component-with-branches labs:"${{ env.LABS_BRANCH }}"
             --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"           

--- a/.github/workflows/build-all-site.yml
+++ b/.github/workflows/build-all-site.yml
@@ -1,5 +1,4 @@
-name: Publish PR preview
-
+name: Build documentation site without publish preview
 on:
   pull_request:
     # To manage 'surge-preview' action teardown, add default event types + closed event type
@@ -18,7 +17,7 @@ on:
       - 'package-lock.json'
 
 jobs:
-  build_preview:
+  build_site:
     runs-on: ubuntu-20.04
     permissions:
       pull-requests: write # surge-preview creates or updates PR comments about the deployment status
@@ -34,19 +33,15 @@ jobs:
           echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
       - uses: actions/checkout@v3 # access to the local action
       - name: Build and publish PR preview
-        uses: ./.github/actions/build-and-publish-pr-preview
+        uses: ./.github/actions/build-pr-site
         with:
-          surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           doc-site-branch: ${{ env.BRANCH_NAME }}
-          publish-preview: 'false'
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
             --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"            
-            --component-with-branches bonita:"${{ env.BCD_BRANCH }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
             --component-with-branches labs:"${{ env.LABS_BRANCH }}"
-            --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
-            --ignore-error true
+            --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"           

--- a/.github/workflows/build-all-site.yml
+++ b/.github/workflows/build-all-site.yml
@@ -6,10 +6,9 @@ on:
     branches:
       - master
     paths:
-      - '.github/actions/build-and-publish-pr-preview/**/*'
       - '.github/actions/build-setup/**/*'
       - '.github/actions/build-pr-site/**/*'
-      - '.github/workflows/publish-pr-preview.yml'
+      - '.github/workflows/build-all-site.yml'
       - 'resources/**/*'
       - 'antora-playbook.yml'
       - 'build-preview.bash'
@@ -31,7 +30,7 @@ jobs:
         uses: ./.github/actions/build-pr-site
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          doc-site-branch: ${{ github.head_ref }}
+          doc-site-branch:
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
@@ -40,4 +39,4 @@ jobs:
             --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
             --component-with-branches labs:"${{ env.LABS_BRANCH }}"
-            --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"           
+            --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"

--- a/.github/workflows/build-pr-site.yml
+++ b/.github/workflows/build-pr-site.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - '.github/actions/build-setup/**/*'
       - '.github/actions/build-pr-site/**/*'
-      - '.github/workflows/build-all-site.yml'
+      - '.github/workflows/build-pr-site.yml'
       - 'resources/**/*'
       - 'antora-playbook.yml'
       - 'build-preview.bash'

--- a/.github/workflows/build-pr-site.yml
+++ b/.github/workflows/build-pr-site.yml
@@ -1,8 +1,6 @@
 name: PR Build documentation site
 on:
   pull_request:
-    # To manage 'surge-preview' action teardown, add default event types + closed event type
-    types: [opened, synchronize, reopened, closed]
     branches:
       - master
     paths:

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -46,7 +46,7 @@ jobs:
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
             --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"            
-            --component-with-branches bonita:"${{ env.BCD_BRANCH }}"
+            --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
             --component-with-branches labs:"${{ env.LABS_BRANCH }}"
             --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -9,7 +9,6 @@ on:
     paths:
       - '.github/actions/build-and-publish-pr-preview/**/*'
       - '.github/actions/build-setup/**/*'
-      - '.github/actions/build-pr-site/**/*'
       - '.github/workflows/publish-pr-preview.yml'
       - 'resources/**/*'
       - 'antora-playbook.yml'

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -32,5 +32,4 @@ jobs:
           doc-site-branch: ${{ github.head_ref }}
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
-          build-preview-command: >-
-            ./build-preview.bash --single-branch-per-repo --ignore-error
+          build-preview-command: ./build-preview.bash --single-branch-per-repo --ignore-error true

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -3,7 +3,7 @@ name: Publish PR preview
 on:
   pull_request:
     # To manage 'surge-preview' action teardown, add default event types + closed event type
-    types: [opened, synchronize, reopened, closed]
+    types: [ opened, synchronize, reopened, closed ]
     branches:
       - master
     paths:
@@ -27,7 +27,7 @@ jobs:
         run: |
           echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
       - uses: actions/checkout@v3 # access to the local action
-      - name: Build and publish PR preview
+      - name: Publish PR preview
         uses: ./.github/actions/build-and-publish-pr-preview
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
@@ -35,8 +35,7 @@ jobs:
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
-            ./build-preview.bash
-            --single-branch-per-repo true
+            ./build-preview.bash --single-branch-per-repo true
             --component bonita
             --component bcd
             --component cloud

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -23,9 +23,6 @@ jobs:
     permissions:
       pull-requests: write # surge-preview creates or updates PR comments about the deployment status
     steps:
-      - name: Compute environment variables
-        run: |
-          echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
       - uses: actions/checkout@v3 # access to the local action
       - name: Publish PR preview
         uses: ./.github/actions/build-and-publish-pr-preview
@@ -36,10 +33,4 @@ jobs:
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
-            ./build-preview.bash --single-branch-per-repo true
-            --component bonita
-            --component bcd
-            --component cloud
-            --component labs
-            --component test-toolkit
-            --ignore-error true
+            ./build-preview.bash --single-branch-per-repo --ignore-error

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -10,6 +10,7 @@ on:
       - '.github/actions/build-and-publish-pr-preview/**/*'
       - '.github/actions/build-setup/**/*'
       - '.github/actions/build-pr-site/**/*'
+      - '.github/workflows/build-all-site.yml'
       - '.github/workflows/publish-pr-preview.yml'
       - 'resources/**/*'
       - 'antora-playbook.yml'
@@ -38,7 +39,7 @@ jobs:
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          doc-site-branch: ${{ env.BRANCH_NAME }}
+          doc-site-branch: ${{ github.head_ref }}
           publish-preview: 'false'
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -42,8 +42,8 @@ jobs:
           # '-' No newline at end (strip)
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
-            --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"
-            --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
+            --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"            
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
             --component-with-branches labs:"${{ env.LABS_BRANCH }}"
             --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
+            --ignore-error true

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          doc-site-branch: ${{ github.head_ref }}
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -10,7 +10,6 @@ on:
       - '.github/actions/build-and-publish-pr-preview/**/*'
       - '.github/actions/build-setup/**/*'
       - '.github/actions/build-pr-site/**/*'
-      - '.github/workflows/build-all-site.yml'
       - '.github/workflows/publish-pr-preview.yml'
       - 'resources/**/*'
       - 'antora-playbook.yml'
@@ -23,12 +22,6 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       pull-requests: write # surge-preview creates or updates PR comments about the deployment status
-    env:
-      BONITA_BRANCH: '2021.2,2022.2'
-      BCD_BRANCH: '3.5'
-      CLOUD_BRANCH: 'master'
-      LABS_BRANCH: 'master'
-      TOOLKIT_BRANCH: '1.0'
     steps:
       - name: Compute environment variables
         run: |
@@ -39,15 +32,14 @@ jobs:
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          doc-site-branch: ${{ github.head_ref }}
-          publish-preview: 'false'
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
-            ./build-preview.bash --use-multi-repositories
-            --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"            
-            --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
-            --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
-            --component-with-branches labs:"${{ env.LABS_BRANCH }}"
-            --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
+            ./build-preview.bash
+            --single-branch-per-repo true
+            --component bonita
+            --component bcd
+            --component cloud
+            --component labs
+            --component test-toolkit
             --ignore-error true

--- a/build-preview.bash
+++ b/build-preview.bash
@@ -46,7 +46,7 @@ function usage() {
   echo "      --use-all-repositories <boolean>        If set to 'true', use all sources repositories and branches defined in the production Antora playbook. Defaults to 'false'"
   echo "      --use-multi-repositories <boolean>      If set to 'true', use several repositories and branches passed with the --component-with-branches options. Defaults to 'false'"
   echo "      --use-test-sources <boolean>            If set to 'true', use documentation stored in the bonita-documentation-site repository (for testing). Defaults to 'false'"
-
+  echo "      --ignore-error <boolean>                If set to 'true', set failure_level to info, if false, set failure_level to error"
   echo "Environment configuration"
   echo "      --only-generate-playbook                If set, only generate the preview Antora playbook and skip the documentation generation"
 }

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -206,9 +206,6 @@ doc.runtime.fetch = fetchSources === 'true';
 //Set log level to info to not break build for preview
 if(ignoreError === 'true'){
     delete doc.runtime.log.failure_level;
-    console.log('## ignoreError', doc.runtime.log);
-} else {
-    doc.runtime.log.failure_level = 'error';
 }
 
 

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -204,7 +204,13 @@ const ignoreError = getArgument(argv, 'ignore-error', false);
 console.info(`Fetch Sources: ${fetchSources}`);
 doc.runtime.fetch = fetchSources === 'true';
 //Set log level to info to not break build for preview
-doc.runtime.log.failure_level = ignoreError === 'true' ? 'warn' : 'error';
+if(ignoreError === 'true'){
+    delete doc.runtime.log.failure_level;
+    console.log('## ignoreError', doc.runtime.log);
+} else {
+    doc.runtime.log.failure_level = 'error';
+}
+
 
 // Set the non-production mode (custom navbar for preview)
 const forceProductionNavbar = getArgument(argv, 'force-production-navbar', false)

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -200,8 +200,11 @@ switch (previewType) {
 
 // Fetch sources
 const fetchSources = getArgument(argv, 'fetch-sources', false)
+const ignoreError = getArgument(argv, 'ignore-error', false);
 console.info(`Fetch Sources: ${fetchSources}`);
 doc.runtime.fetch = fetchSources === 'true';
+//Set log level to info to not break build for preview
+doc.runtime.log.failure_level = ignoreError === 'true' ? 'warn' : 'error';
 
 // Set the non-production mode (custom navbar for preview)
 const forceProductionNavbar = getArgument(argv, 'force-production-navbar', false)


### PR DESCRIPTION
* Always deploy pr-preview to allow contributors to see theirs updates
* Separate Build and deploy PR in two worflows
* Keep old build-and-pr-preview action but use a new param to ignore-error on demand

Cover https://github.com/bonitasoft/bonita-documentation-site/issues/399