### PR TITLE
ci: provide more information in the logs about the generated site

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/README.md
+++ b/.github/actions/build-and-publish-pr-preview/README.md
@@ -1,0 +1,7 @@
+# build and publish pr preview
+
+**WARN**: Only work on Ubuntu runners
+
+Manage the surge preview deployment. In particular, teardown the surge deployment when closing the Pull Request.
+
+If the site preview cannot be deployed, the site is uploaded as an artifact of the run.

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -37,6 +37,13 @@ runs:
       if: github.event.action != 'closed'
       shell: bash
       run: ${{ inputs.build-preview-command }} --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+    - name: List generated site
+      if: github.event.action != 'closed'
+      working-directory: build/site
+      shell: bash
+      run: |
+        ls -lh
+        du --max-depth=2 -h
     - name: Publish preview
       uses: afc163/surge-preview@v1
       if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
@@ -46,5 +53,4 @@ runs:
         dist: build/site
         failOnError: true
         teardown: true
-        build: |
-          ls -lh build/site
+        build: echo "site already built"

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -37,7 +37,7 @@ runs:
       if: github.event.action != 'closed'
       shell: bash
       run: ${{ inputs.build-preview-command }} --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
-    - name: List generated site
+    - name: List the content of the generated site
       if: github.event.action != 'closed'
       working-directory: build/site
       shell: bash

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -54,3 +54,11 @@ runs:
         failOnError: true
         teardown: true
         build: echo "site already built"
+    - name: Archive site preview
+      # TODO add to the if close: && steps.surge-preview-tools.outputs.can-run-surge-command != 'true'
+      if: github.event.action != 'closed'
+      uses: actions/upload-artifact@v3
+      with:
+        # TODO repo name in name
+        name: site-preview-${{github.event.pull_request.number}}-${{github.sha}}
+        path: build/site

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -55,10 +55,8 @@ runs:
         teardown: true
         build: echo "site already built"
     - name: Archive site preview
-      # TODO add to the if close: && steps.surge-preview-tools.outputs.can-run-surge-command != 'true'
-      if: github.event.action != 'closed'
+      if: github.event.action != 'closed' && steps.surge-preview-tools.outputs.can-run-surge-command != 'true'
       uses: actions/upload-artifact@v3
       with:
-        # TODO repo name in name
-        name: site-preview-${{github.event.pull_request.number}}-${{github.sha}}
+        name: site-preview-pr-${{github.event.pull_request.number}}-${{github.sha}}
         path: build/site

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -44,8 +44,13 @@ jobs:
         uses: ./.github/actions/build-setup
       - name: Install dependencies
         run: npm ci
-      - name: Build docs
+      - name: Build site
         run: GOOGLE_ANALYTICS_KEY=${{env.GOOGLE_ANALYTICS_KEY}} npm run build
+      - name: List the content of the generated site
+        working-directory: build/site
+        run: |
+          ls -lh
+          du --max-depth=2 -h
       - name: Create deploy message if no component defined
         if: ( github.event_name == 'workflow_dispatch' ||  github.event_name == 'repository_dispatch' ) && env.COMPONENT == ''
         run:


### PR DESCRIPTION
Preview
- log the size of the site files
- upload an artifact when the site cannot be deployed to surge (fork repository, dependabot)
- add README to provide basic information about the action

Production: List the content of the generated site (files and size)


closes #403