### PR TITLE
ci: automate bcd doc content propagation from versions to versions

### DIFF
--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -11,7 +11,7 @@ on:
       slack-notifications:
         description: 'If true, send slack notifications when errors occur'
         required: false
-        default: 'true'
+        default: 'false'
 
 jobs:
   propagate-doc-upwards:

--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -20,7 +20,7 @@ jobs:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
-        repo: [bonita-doc]
+        repo: [bonita-doc,bonita-continuous-delivery-doc]
     steps:
       - name: Checkout bonita-documentation-site
         uses: actions/checkout@v3

--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -52,8 +52,7 @@ jobs:
           ./.././bonita-documentation-site/scripts/propagate_doc_upwards.bash
 
       - name: Send message to Slack channel
-        # TODO do not skip if event is 'schedule'
-        if: failure() && github.event.inputs.slack-notifications == 'true'
+        if: failure() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.slack-notifications == 'true') )
         uses: slackapi/slack-github-action@v1.21.0
         with:
           channel-id: 'CCQGMR4ES'

--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -52,6 +52,7 @@ jobs:
           ./.././bonita-documentation-site/scripts/propagate_doc_upwards.bash
 
       - name: Send message to Slack channel
+        # TODO do not skip if event is 'schedule'
         if: failure() && github.event.inputs.slack-notifications == 'true'
         uses: slackapi/slack-github-action@v1.21.0
         with:

--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -8,29 +8,39 @@ on:
         description: 'If true, run the merge locally but do not push to remote'
         required: false
         default: 'false'
+      slack-notifications:
+        description: 'If true, send slack notifications when errors occur'
+        required: false
+        default: 'true'
 
 jobs:
   propagate-doc-upwards:
     runs-on: ubuntu-20.04
+    strategy:
+      # we want to run the full build on all os: don't cancel running jobs even if one fails
+      fail-fast: false
+      matrix:
+        repo: [bonita-doc]
     steps:
       - name: Checkout bonita-documentation-site
         uses: actions/checkout@v3
         with:
           path: ./bonita-documentation-site
-      - name: Checkout bonita-doc
+      - name: Checkout ${{ matrix.repo }}
         uses: actions/checkout@v3
         with:
           repository: bonitasoft/bonita-doc
           token: ${{ secrets.GH_PAT_TOKEN }} # Dedicated token to have 'write permission' (we later push to this repository)
-          path: ./bonita-doc
+          path: ./${{ matrix.repo }}
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: '0'
 
       - name: Run propagate doc upwards
         env:
           NO_PUSH: ${{ github.event.inputs.dry-run }}
+          REPO_NAME: ${{ matrix.repo }}
         run: |
-          cd ./bonita-doc
+          cd ./${{ matrix.repo }}
           
           # configure committer information
           git config user.email "actions@github.com"
@@ -42,7 +52,7 @@ jobs:
           ./.././bonita-documentation-site/scripts/propagate_doc_upwards.bash
 
       - name: Send message to Slack channel
-        if: failure()
+        if: failure() && $ github.event.inputs.slack-notifications == 'true'
         uses: slackapi/slack-github-action@v1.21.0
         with:
           channel-id: 'CCQGMR4ES'
@@ -53,7 +63,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":fire:  Propagation documentation upwards failed. \n \n  @channel *We need someone* ! \n  - Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required) \n - Add a :sweat_drops: when it’s done (and eventually a :party_parrot: )"
+                    "text": ":fire:  Propagating documentation upwards failed for repository **${{matrix.repo}}**. \n \n  @channel *We need someone* ! \n  - Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required) \n - Add a :sweat_drops: when it’s done (and eventually a :party_parrot: )"
                   }
                 },
                 {

--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -26,13 +26,13 @@ jobs:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: '0'
 
-      - name: Run propagate doc updward
+      - name: Run propagate doc upwards
         env:
           NO_PUSH: ${{ github.event.inputs.dry-run }}
         run: |
           cd ./bonita-doc
           
-          # configure commiter information
+          # configure committer information
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
                    

--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout ${{ matrix.repo }}
         uses: actions/checkout@v3
         with:
-          repository: bonitasoft/bonita-doc
+          repository: bonitasoft/${{ matrix.repo }}
           token: ${{ secrets.GH_PAT_TOKEN }} # Dedicated token to have 'write permission' (we later push to this repository)
           path: ./${{ matrix.repo }}
           # Number of commits to fetch. 0 indicates all history for all branches and tags.

--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -52,7 +52,7 @@ jobs:
           ./.././bonita-documentation-site/scripts/propagate_doc_upwards.bash
 
       - name: Send message to Slack channel
-        if: failure() && $ github.event.inputs.slack-notifications == 'true'
+        if: failure() && github.event.inputs.slack-notifications == 'true'
         uses: slackapi/slack-github-action@v1.21.0
         with:
           channel-id: 'CCQGMR4ES'

--- a/scripts/propagate_doc_upwards.bash
+++ b/scripts/propagate_doc_upwards.bash
@@ -47,7 +47,7 @@ log "Configuration: REPO_NAME=${REPO_NAME}"
 # allow to keep our changes when merge=ours specified in .gitattributes
 git config merge.ours.driver true
 
-if [ "${REPO_NAME}" == "bonita-doc"]; then
+if [ "${REPO_NAME}" == "bonita-doc" ]; then
   merge "2021.1" "2021.2"
   merge "2021.2" "2022.1"
   merge "2022.1" "2022.2"
@@ -57,4 +57,5 @@ elif [ "${REPO_NAME}" == "bonita-continuous-delivery-doc" ]; then
   merge "3.5" "3.6"
 else
   echo "ERROR: Unsupported repository ${REPO_NAME}"
+  exit -1
 fi

--- a/scripts/propagate_doc_upwards.bash
+++ b/scripts/propagate_doc_upwards.bash
@@ -4,6 +4,8 @@ set -euo pipefail
 # To locally test the script, you can set the following environment variables
 # NO_PUSH=true  skip the push to the remote repository
 NO_PUSH=${NO_PUSH:-false}
+#
+REPO_NAME=${REPO_NAME:-bonita}
 
 log() {
   echo "> $1"
@@ -42,7 +44,14 @@ log "Configuration: NO_PUSH=${NO_PUSH}"
 # allow to keep our changes when merge=ours specified in .gitattributes
 git config merge.ours.driver true
 
-merge "2021.1" "2021.2"
-merge "2021.2" "2022.1"
-merge "2022.1" "2022.2"
-merge "2022.2" "2023.1"
+if [ "${REPO_NAME}" == "bonita"]; then
+  merge "2021.1" "2021.2"
+  merge "2021.2" "2022.1"
+  merge "2022.1" "2022.2"
+  merge "2022.2" "2023.1"
+elif [ "${REPO_NAME}" == "bcd" ]; then
+  merge "3.4" "3.5"
+  merge "3.5" "3.6"
+else
+  echo "ERROR: Unsupported repository ${REPO_NAME}"
+fi

--- a/scripts/propagate_doc_upwards.bash
+++ b/scripts/propagate_doc_upwards.bash
@@ -4,8 +4,10 @@ set -euo pipefail
 # To locally test the script, you can set the following environment variables
 # NO_PUSH=true  skip the push to the remote repository
 NO_PUSH=${NO_PUSH:-false}
-#
-REPO_NAME=${REPO_NAME:-bonita}
+# Select the name the repository to
+#   bonita: bonita-doc
+#   bcd:    bonita-continuous-delivery-doc
+REPO_NAME=${REPO_NAME:-bonita-doc}
 
 log() {
   echo "> $1"
@@ -40,6 +42,7 @@ merge() {
 
 log "Propagating documentation upwards"
 log "Configuration: NO_PUSH=${NO_PUSH}"
+log "Configuration: REPO_NAME=${REPO_NAME}"
 
 # allow to keep our changes when merge=ours specified in .gitattributes
 git config merge.ours.driver true

--- a/scripts/propagate_doc_upwards.bash
+++ b/scripts/propagate_doc_upwards.bash
@@ -47,12 +47,12 @@ log "Configuration: REPO_NAME=${REPO_NAME}"
 # allow to keep our changes when merge=ours specified in .gitattributes
 git config merge.ours.driver true
 
-if [ "${REPO_NAME}" == "bonita"]; then
+if [ "${REPO_NAME}" == "bonita-doc"]; then
   merge "2021.1" "2021.2"
   merge "2021.2" "2022.1"
   merge "2022.1" "2022.2"
   merge "2022.2" "2023.1"
-elif [ "${REPO_NAME}" == "bcd" ]; then
+elif [ "${REPO_NAME}" == "bonita-continuous-delivery-doc" ]; then
   merge "3.4" "3.5"
   merge "3.5" "3.6"
 else


### PR DESCRIPTION
Update the existing configuration
- scripts updated to manage both bcd and bonita
- the workflow runs both bcd and bonita updates
- add an option to not send slack notification when the workflow is run manually (useful for tests and debugging)

closes #410

### For reviewers

Tested manually in dry-run
I didn't check the slack notifications.