### PR TITLE
ci(slack): fix bold style for "repository"

### DIFF
--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -63,7 +63,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":fire:  Propagating documentation upwards failed for repository **${{matrix.repo}}**. \n \n  @channel *We need someone* ! \n  - Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required) \n - Add a :sweat_drops: when it’s done (and eventually a :party_parrot: )"
+                    "text": ":fire:  Propagating documentation upwards failed for repository *${{matrix.repo}}*. \n \n  @channel *We need someone* ! \n  - Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required) \n - Add a :sweat_drops: when it’s done (and eventually a :party_parrot: )"
                   }
                 },
                 {


### PR DESCRIPTION
The Markdown syntax was incorrect, the name of the repository in the error message was surrounded by 2 asterisks (**) instead of being in bold.

Here is how the message looked like prior the fix:

![image](https://user-images.githubusercontent.com/27200110/191455816-ee132dd9-967a-4e25-ba02-1ecdfb3089ae.png)
