### PR TITLE
chore: move special CI configuration out of the preview script

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -39,11 +39,11 @@ runs:
     - name: Build Site without error check
       if: github.event.action != 'closed' && inputs.component-name != ''
       shell: bash
-      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error true --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: Build Site
       if: github.event.action != 'closed' && inputs.component-name == ''
       shell: bash
-      run: ${{ inputs.build-preview-command }} --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+      run: ${{ inputs.build-preview-command }} --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: List the content of the generated site
       if: github.event.action != 'closed'
       working-directory: build/site

--- a/.github/actions/build-pr-site/action.yml
+++ b/.github/actions/build-pr-site/action.yml
@@ -26,4 +26,4 @@ runs:
     - name: Build Site
       if: github.event.action != 'closed'
       shell: bash
-      run: ${{ inputs.build-preview-command }} --pr "${{ github.event.pull_request.number }}"
+      run: ${{ inputs.build-preview-command }} --fetch-sources true --pr "${{ github.event.pull_request.number }}"

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -8,3 +8,7 @@ runs:
       with:
         node-version: '16'
         cache: 'npm'
+    - name: Install dependencies
+      uses: bahmutov/npm-install@v1
+      with:
+        install-command: npm ci --ignore-scripts --prefer-offline --audit false

--- a/.github/workflows/generate-static-doc.yml
+++ b/.github/workflows/generate-static-doc.yml
@@ -26,10 +26,13 @@ jobs:
       - name: Build Setup
         uses: ./.github/actions/build-setup
       - name: Generate static documentation
-        run: |
-            ./build-preview.bash --branch "${{ github.event.inputs.branch }}" --component "${{ github.event.inputs.component }}" \
-                                 --site-title "${{ github.event.inputs.title }}" \
-                                 --type local --site-url DISABLED --hide-edit-page-links true --hide-navbar-components-list true
+        # '>' Replace newlines with spaces (folded)
+        run: >
+          ./build-preview.bash 
+            --branch "${{ github.event.inputs.branch }}" --component "${{ github.event.inputs.component }}"
+            --fetch-sources true
+            --site-title "${{ github.event.inputs.title }}"
+            --type local --site-url DISABLED --hide-edit-page-links true --hide-navbar-components-list true
       - name: Zip docs
         if: (github.event.inputs.newRelease == 'true')
         run: |

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -29,6 +29,4 @@ jobs:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           doc-site-branch: ${{ github.head_ref }}
-          # '>' Replace newlines with spaces (folded)
-          # '-' No newline at end (strip)
           build-preview-command: ./build-preview.bash --single-branch-per-repo --ignore-error true

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -42,8 +42,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Build Setup
         uses: ./.github/actions/build-setup
-      - name: Install dependencies
-        run: npm ci
       - name: Build site
         run: GOOGLE_ANALYTICS_KEY=${{env.GOOGLE_ANALYTICS_KEY}} npm run build
       - name: List the content of the generated site

--- a/README.adoc
+++ b/README.adoc
@@ -52,7 +52,7 @@ Follow the {url-nvm-install}[nvm installation instructions] to set up nvm on you
 
 Don't forget to run `npm install` the first time you build the project or on `package.json` changes.
 
-Check that the `Antora` CLI is available by calling `./node_modules/.bin/antora --version`.
+Check that the `Antora` CLI is available by calling `npx antora --version`.
 
 
 [#non-production-build]

--- a/build-preview.bash
+++ b/build-preview.bash
@@ -55,11 +55,9 @@ function usage() {
 ########################################################################################################################
 # Parse arguments
 ########################################################################################################################
-extraAntoraOptions=
-# the environment variable is set to true by GitHub Actions
-CI=${CI:-false}
 
 scriptOptions="$@"
+echo "Preparing the preview build"
 echo "Script Options: ${scriptOptions}"
 
 # Help
@@ -69,24 +67,10 @@ if [[ "$scriptOptions" == *"--help"* ]]; then
 fi
 
 
-if [[ $CI == "true" ]]; then
-  echo "Assume script is running on CI environment"
-  # force fetch, whatever the script options are
-  extraAntoraOptions="--fetch"
-else
-  echo "Assume script is NOT running on CI environment"
-fi
-
-echo "Extra Antora Options: ${extraAntoraOptions}"
-
-
 ########################################################################################################################
 # PROCESSING
 ########################################################################################################################
-if [[ $CI == "true" ]]; then
-  echo "Using node $(node --version) and npm $(npm --version)"
-  npm ci
-fi
+
 # See the node script for the list of arguments
 node scripts/generate-content-for-preview-antora-playbook.js ${scriptOptions}
 
@@ -94,7 +78,7 @@ if [[ "$scriptOptions" == *"--only-generate-playbook"* ]]; then
   echo "Skip documentation generation"
   exit 0
 fi
-echo "Building preview..."
+echo "Building the preview using Node $(node --version)..."
 rm -rf build/
-./node_modules/.bin/antora --stacktrace ${extraAntoraOptions} antora-playbook-content-for-preview.yml
+npx antora --stacktrace antora-playbook-content-for-preview.yml
 echo "Preview built"


### PR DESCRIPTION
Historically, the preview script was directly called by a lot of GitHub workflows. To avoid to duplicate the `npm ci` setup and ensure that Antora fetches sources, it was easier to do it in the script.
Now, all documentation content repositories use the GitHub actions provided by the bonita-documentation-site repository, so the extra settings can be managed by the shared actions.

This move provides a better separation of concerns. The script only focuses on generating the preview without managing special cases depending on the environment. The `npm ci` command is called directly in the `build-setup` internal action, where everybody expects to find it. This allows to introduce the usage of the GitHub cache for the npm dependencies, so we can expect fastest builds.
This also ensures consistency between the build and publish PR preview, and the "publishing to production" workflows that are no more doing `npm ci` in a different way.

In addition, we now run and advice to run Antora via `npx` as suggested by the Antora documentation.

### Notes

About the usage of npx for Antora, see
- https://github.com/couchbase/docs-site/pull/503/files#diff-0e8a7c2f91f241f59cc684e048c14593122447d39c4b8bfa6953cb5e91151aa2 
- all content repositories are using the actions of this repo. The latest one was bcd and it has been updated yesterday to use the action. See #418