### PR TITLE
ci: run all GitHub workflows on Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-pr-site.yml
+++ b/.github/workflows/build-pr-site.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build_site:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BONITA_BRANCH: '2021.2,2022.2'
       BCD_BRANCH: '3.5'

--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-for-cc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: check-for-cc
         id: check-for-cc

--- a/.github/workflows/generate-static-doc.yml
+++ b/.github/workflows/generate-static-doc.yml
@@ -19,7 +19,7 @@ on:
         required: true
 jobs:
   generate_static_doc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/manage-surge-deployments.yml
+++ b/.github/workflows/manage-surge-deployments.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   list_deployments:
     if: github.event.inputs.teardown != 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: List deployments
         run: |
@@ -20,7 +20,7 @@ jobs:
 
   teardown_deployments:
     if: github.event.inputs.teardown == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Teardown deployments
         run: |

--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   propagate-doc-upwards:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build_preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write # surge-preview creates or updates PR comments about the deployment status
     steps:

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -32,7 +32,7 @@ permissions:
 
 jobs:
   deploy_to_netlify:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GOOGLE_ANALYTICS_KEY: GTM-TXHBK7
       COMPONENT: ${{ github.event.client_payload.component || github.event.inputs.component }}

--- a/.github/workflows/teardown-inactive-surge-deployments.yml
+++ b/.github/workflows/teardown-inactive-surge-deployments.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   teardown_inactive_deployement:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Teardown surge deployement inactive than more 1 month
         uses: adrianjost/actions-surge.sh-teardown@v1.0.3

--- a/.github/workflows/update-theme-bundle.yml
+++ b/.github/workflows/update-theme-bundle.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The Ubuntu 22.04 runner is in GA and is stable, so we can safely use it.