### PR TITLE
ci: upload artifact when building PR site

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -17,6 +17,7 @@ inputs:
     required: false
     default: 'master'
   component-name:
+    description: 'The name of the component to build. If set, the build-preview-command input is ignored'
     required: false
     default: ''
 
@@ -46,11 +47,7 @@ runs:
       run: ${{ inputs.build-preview-command }} --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: List the content of the generated site
       if: github.event.action != 'closed'
-      working-directory: build/site
-      shell: bash
-      run: |
-        ls -lh
-        du --max-depth=2 -h
+      uses: ./.github/actions/log-built-site-details
     - name: Publish preview
       uses: afc163/surge-preview@v1
       if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
@@ -63,7 +60,6 @@ runs:
         build: echo "site already built"
     - name: Archive site preview
       if: github.event.action != 'closed' && steps.surge-preview-tools.outputs.can-run-surge-command != 'true'
-      uses: actions/upload-artifact@v3
+      uses: ./.github/actions/upload-pr-built-site-artifact
       with:
-        name: site-preview-pr-${{github.event.pull_request.number}}-${{github.sha}}
-        path: build/site
+        site-type: preview

--- a/.github/actions/build-pr-site/action.yml
+++ b/.github/actions/build-pr-site/action.yml
@@ -16,14 +16,18 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v3
-      if: github.event.action != 'closed'
       with:
         repository: 'bonitasoft/bonita-documentation-site'
         ref: ${{ inputs.doc-site-branch }}
     - name: Build Setup
       uses: ./.github/actions/build-setup
-      if: github.event.action != 'closed'
     - name: Build Site
-      if: github.event.action != 'closed'
       shell: bash
       run: ${{ inputs.build-preview-command }} --fetch-sources true --pr "${{ github.event.pull_request.number }}"
+    - name: List the content of the generated site
+      uses: ./.github/actions/log-built-site-details
+    - name: Archive site
+      if: github.event.action != 'closed' && steps.surge-preview-tools.outputs.can-run-surge-command != 'true'
+      uses: ./.github/actions/upload-pr-built-site-artifact
+      with:
+        site-type: build

--- a/.github/actions/log-built-site-details/action.yml
+++ b/.github/actions/log-built-site-details/action.yml
@@ -1,0 +1,12 @@
+name: 'Log built site details'
+description: 'Log directories list, size, ...'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Log details
+      working-directory: build/site
+      shell: bash
+      run: |
+        ls -lh
+        du --max-depth=2 -h

--- a/.github/actions/upload-pr-built-site-artifact/action.yml
+++ b/.github/actions/upload-pr-built-site-artifact/action.yml
@@ -1,0 +1,16 @@
+name: 'Upload the built site'
+description: 'For PR only. Upload an artifact containing the built site.'
+
+inputs:
+  site-type:
+    description: 'Used in the name of the artifact, to identify the artifact from the others'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: site-${{inputs.site-type}}-pr-${{github.event.pull_request.number}}-${{github.sha}}
+        path: build/site

--- a/.github/workflows/build-pr-site.yml
+++ b/.github/workflows/build-pr-site.yml
@@ -17,7 +17,7 @@ jobs:
   build_site:
     runs-on: ubuntu-22.04
     env:
-      BONITA_BRANCHES: '2021.2,2022.2'
+      BONITA_BRANCHES: '2021.2,2022.1,2022.2'
       BCD_BRANCHES: '3.5,3.6'
       CLOUD_BRANCH: 'master'
       LABS_BRANCH: 'master'

--- a/.github/workflows/build-pr-site.yml
+++ b/.github/workflows/build-pr-site.yml
@@ -17,8 +17,8 @@ jobs:
   build_site:
     runs-on: ubuntu-22.04
     env:
-      BONITA_BRANCH: '2021.2,2022.2'
-      BCD_BRANCH: '3.5'
+      BONITA_BRANCHES: '2021.2,2022.2'
+      BCD_BRANCHES: '3.5,3.6'
       CLOUD_BRANCH: 'master'
       LABS_BRANCH: 'master'
       TOOLKIT_BRANCH: '1.0'
@@ -32,8 +32,8 @@ jobs:
           # '-' No newline at end (strip)
           build-preview-command: >-
             ./build-preview.bash --use-multi-repositories
-            --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"
-            --component-with-branches bcd:"${{ env.BCD_BRANCH }}"
+            --component-with-branches bonita:"${{ env.BONITA_BRANCHES }}"
+            --component-with-branches bcd:"${{ env.BCD_BRANCHES }}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
             --component-with-branches labs:"${{ env.LABS_BRANCH }}"
             --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"

--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -45,10 +45,7 @@ jobs:
       - name: Build site
         run: GOOGLE_ANALYTICS_KEY=${{env.GOOGLE_ANALYTICS_KEY}} npm run build
       - name: List the content of the generated site
-        working-directory: build/site
-        run: |
-          ls -lh
-          du --max-depth=2 -h
+        uses: ./.github/actions/log-built-site-details
       - name: Create deploy message if no component defined
         if: ( github.event_name == 'workflow_dispatch' ||  github.event_name == 'repository_dispatch' ) && env.COMPONENT == ''
         run:


### PR DESCRIPTION
This applies to the shared action, which is used in documentation content repositories and in this repository as well.
Also log the details of the generated files.

Introduce new shared actions to remove duplication
  - upload the artifact of the site
  - log built site details

Fix the `build-pr-site` workflow: it requires bcd 3.6, bonita 2022.1 to make xref validation pass