### PR TITLE
ci(preview-action): add ignore-errors input

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'The name of the component to build. If set, the build-preview-command input is ignored'
     required: false
     default: ''
+  ignore-error:
+    description: 'Only applies when the `component-name` input is set. If `true` ignore Antora error.'
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
@@ -40,7 +44,7 @@ runs:
     - name: Build Site without error check
       if: github.event.action != 'closed' && inputs.component-name != ''
       shell: bash
-      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error true --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error ${{inputs.ignore-error}} --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: Build Site
       if: github.event.action != 'closed' && inputs.component-name == ''
       shell: bash

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: 'The name of the component to build. If set, the build-preview-command input is ignored'
     required: false
     default: ''
-  ignore-error:
+  ignore-errors:
     description: 'Only applies when the `component-name` input is set. If `true` ignore Antora error.'
     required: false
     default: 'true'
@@ -44,7 +44,7 @@ runs:
     - name: Build Site without error check
       if: github.event.action != 'closed' && inputs.component-name != ''
       shell: bash
-      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error ${{inputs.ignore-error}} --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error ${{inputs.ignore-errors}} --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: Build Site
       if: github.event.action != 'closed' && inputs.component-name == ''
       shell: bash

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: ''
   ignore-errors:
-    description: 'Only applies when the `component-name` input is set. If `true` ignore Antora error.'
+    description: 'Only applies when the `component-name` input is set. If `true`, ignores Antora error.'
     required: false
     default: 'true'
 


### PR DESCRIPTION
The new input allows to build and deploy the PR preview but also to validate xref.
Currently, this is needed for documentation component that have no xref to other components. See https://github.com/bonitasoft/bonita-labs-doc/pull/139
In the future, when `Antora Atlas` will be used (#326), all documentation content repositories will progressively do xref validation as part of the preview build.