### PR TITLE
chore(deps-gha): bump surge-preview-tools from v1 to v2

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: bonitasoft/actions/packages/surge-preview-tools@v1
+    - uses: bonitasoft/actions/packages/surge-preview-tools@v2
       id: surge-preview-tools
       with:
         surge-token: ${{ inputs.surge-token }}


### PR DESCRIPTION
Remove deprecation warning logs.