### PR TITLE
ci: simplify artifact upload in "build-pr-site" action

### DIFF
--- a/.github/actions/build-pr-site/action.yml
+++ b/.github/actions/build-pr-site/action.yml
@@ -27,7 +27,6 @@ runs:
     - name: List the content of the generated site
       uses: ./.github/actions/log-built-site-details
     - name: Archive site
-      if: github.event.action != 'closed' && steps.surge-preview-tools.outputs.can-run-surge-command != 'true'
       uses: ./.github/actions/upload-pr-built-site-artifact
       with:
         site-type: build

--- a/.github/workflows/build-pr-site.yml
+++ b/.github/workflows/build-pr-site.yml
@@ -17,7 +17,7 @@ jobs:
   build_site:
     runs-on: ubuntu-22.04
     env:
-      BONITA_BRANCHES: '2021.2,2022.1,2022.2'
+      BONITA_BRANCHES: '2021.1,2021.2,2022.1,2022.2'
       BCD_BRANCHES: '3.5,3.6'
       CLOUD_BRANCH: 'master'
       LABS_BRANCH: 'master'


### PR DESCRIPTION
Remove an extra if that isn't relevant. It related to surge preview.

Also update the `build-pr-site.yml` workflow: the bonita 2021.1 branch is now required for xref validation.