### PR TITLE
ci: limit runs of the 'pr-title-check' workflow

### DIFF
--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -2,7 +2,7 @@ name: Commit Message format check
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, synchronize]
 
 jobs:
   check-for-cc:

--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -2,11 +2,10 @@ name: Commit Message format check
 
 on:
   pull_request:
-    branches: [master]
-    types: [opened, edited, synchronize]
+    types: [opened, edited, reopened]
 
 jobs:
-  check-for-cc:
+  check-pr-title:
     runs-on: ubuntu-22.04
     steps:
       - name: check-for-cc

--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -2,7 +2,7 @@ name: Commit Message format check
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened]
 
 jobs:
   check-for-cc:

--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, reopened]
 
 jobs:
-  check-pr-title:
+  check-for-cc:
     runs-on: ubuntu-22.04
     steps:
       - name: check-for-cc


### PR DESCRIPTION
Do not run when pushing new code (`synchronize` event) because the PR title doesn't change in this case. Run when reopening PR as the title may have changed while the PR was closed.

**Note**: detected with https://github.com/bonitasoft/bonita-doc/pull/2216