### PR TITLE
feat: improve comments templating (for PR preview)

### DIFF
--- a/.github/actions/comment-pr-with-links/comments-with-url-links.js
+++ b/.github/actions/comment-pr-with-links/comments-with-url-links.js
@@ -15,7 +15,8 @@ module.exports = {
                 splitted.shift();
                 const pageName = splitted.pop();
                 const moduleName = splitted.shift();
-                urls.push(`- ${SITE_URL}/${COMPONENT_NAME}/${pr.base.ref}${moduleName === 'ROOT' ? '/' : `/${moduleName}/`}${pageName?.split('.').shift()}`);
+                let url = `${SITE_URL}/${COMPONENT_NAME}/${pr.base.ref}${moduleName === 'ROOT' ? '/' : `/${moduleName}/`}${pageName?.split('.').shift()}`;
+                urls.push(`[ ][${moduleName}/${pageName}](${url})`);
             });
             return urls.join('\n');
     },

--- a/.github/actions/comment-pr-with-links/comments-with-url-links.js
+++ b/.github/actions/comment-pr-with-links/comments-with-url-links.js
@@ -1,5 +1,5 @@
 const githubUtils = require('./github');
-
+const commentId= '<!-- previewLinksCheck-->\n';
 module.exports = {
     prepareUrlLinks:  async function ({github, context}) {
             let {FILES, SITE_URL, COMPONENT_NAME} = process.env;
@@ -24,7 +24,7 @@ module.exports = {
         let {LINKS, RENAMED_FILES, HAS_DELETED_FILES} = process.env;
         const header='## :memo: Check the pages that have been modified\n\n';
         let body = buildMessage(header,LINKS,HAS_DELETED_FILES === 'true' || RENAMED_FILES != '');
-        const {exists, id} = await githubUtils.isCommentExist({github,context,header});
+        const {exists, id} = await githubUtils.isCommentExist({github,context,commentId});
         // Delete oldest comment if another comments exist
         if (exists && id){
             await githubUtils.deleteComment({github,context,commentIdToDelete: id});
@@ -43,5 +43,5 @@ function buildMessage(header,links,hasWarningMessage){
     if(hasWarningMessage){
         warningAliasMessage='\n \n ### :warning: At least one page has been deleted in the Pull Request. Make sure to add [aliases](https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc#use-alias-to-create-redirects)'    }
 
-    return header + preface + availableLinks + warningAliasMessage;
+    return commentId + header + preface + availableLinks + warningAliasMessage;
 }

--- a/.github/actions/comment-pr-with-links/comments-with-url-links.js
+++ b/.github/actions/comment-pr-with-links/comments-with-url-links.js
@@ -22,7 +22,7 @@ module.exports = {
     },
     createOrUpdateComments: async function ({github,context}){
         let {LINKS, RENAMED_FILES, HAS_DELETED_FILES} = process.env;
-        const header='## :memo: Pull request files update\n\n';
+        const header='## :memo: Check the pages that have been modified\n\n';
         let body = buildMessage(header,LINKS,HAS_DELETED_FILES === 'true' || RENAMED_FILES != '');
         const {exists, id} = await githubUtils.isCommentExist({github,context,header});
         // Delete oldest comment if another comments exist
@@ -37,11 +37,11 @@ function buildMessage(header,links,hasWarningMessage){
     const preface =
         'In order to merge this pull request, you need to check your updates with the following url.\n\n';
 
-    const availableLinks = `### :mag: Url to check: \n ${links}\n\n\n\n`;
+    const availableLinks = `### :mag: Page list: \n ${links}\n\n\n\n`;
     //Adding deleted or renamed check
     let warningAliasMessage = '';
     if(hasWarningMessage){
-        warningAliasMessage='\n \n ### :warning: At least one file are deleted on this pull request, be sure to adding [alias](https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc#use-alias-to-create-redirects)'    }
+        warningAliasMessage='\n \n ### :warning: At least one page has been deleted in the Pull Request. Make sure to add [aliases](https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc#use-alias-to-create-redirects)'    }
 
     return header + preface + availableLinks + warningAliasMessage;
 }

--- a/.github/actions/comment-pr-with-links/comments-with-url-links.js
+++ b/.github/actions/comment-pr-with-links/comments-with-url-links.js
@@ -16,7 +16,7 @@ module.exports = {
                 const pageName = splitted.pop();
                 const moduleName = splitted.shift();
                 let url = `${SITE_URL}/${COMPONENT_NAME}/${pr.base.ref}${moduleName === 'ROOT' ? '/' : `/${moduleName}/`}${pageName?.split('.').shift()}`;
-                urls.push(`[ ][${moduleName}/${pageName}](${url})`);
+                urls.push(`- [ ] ${moduleName}/${pageName}](${url})`);
             });
             return urls.join('\n');
     },

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - '.github/actions/build-and-publish-pr-preview/**/*'
       - '.github/actions/build-setup/**/*'
+      - '.github/actions/comment-pr-with-links/**/*'
       - '.github/workflows/publish-pr-preview.yml'
       - 'resources/**/*'
       - 'antora-playbook.yml'


### PR DESCRIPTION
The actual comments template is ugly when a lot of files is updated in a PR
![image](https://user-images.githubusercontent.com/25297128/201136412-c9d1ab94-984f-4d49-b039-cae974f36281.png)

We suggest adding a checkbox to help users identify which file he has already check.
We replace the link by only the `moduleName/pageName`