### PR TITLE
ci: use bonitasoft/actions pr-title-conventional-commits

### DIFF
--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -1,15 +1,15 @@
-name: Commit Message format check 
+name: Commit Message format check
 
 on:
-  pull_request:
+  pull_request_target:
+    # trigger when the PR title changes
     types: [opened, edited, reopened]
 
 jobs:
-  check-for-cc:
+  pr-title:
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
     steps:
-      - name: check-for-cc
-        id: check-for-cc
-        uses: agenthunt/conventional-commit-checker-action@v1.0.0
-        with:
-          pr-body-regex: '(.*\n*)+(.*)'
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2

--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -1,7 +1,7 @@
 name: Commit Message format check
 
 on:
-  pull_request_target:
+  pull_request:
     # trigger when the PR title changes
     types: [opened, edited, reopened]
 

--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -1,7 +1,7 @@
 name: Commit Message format check
 
 on:
-  pull_request:
+  pull_request_target:
     # trigger when the PR title changes
     types: [opened, edited, reopened]
 


### PR DESCRIPTION
This action better conforms to Conventional Commits and provides guidelines to help to fix wrong PR titles.

covers #422