### PR TITLE
feat: add apps-manager preview tooling

### DIFF
--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -105,6 +105,7 @@ else if (useTestSources) {
         url: './',
         branches: ['HEAD'],
         start_paths: [
+            'test/documentation-content/apps-manager/1.0',
             'test/documentation-content/bcd/3.4',
             'test/documentation-content/bcd/3.5',
             'test/documentation-content/bonita/v0',
@@ -115,9 +116,8 @@ else if (useTestSources) {
             'test/documentation-content/bonita/v2022.1-beta',
             'test/documentation-content/bonita/v2022.2-alpha',
             'test/documentation-content/cloud/latest',
-            'test/documentation-content/test-toolkit/1.0',
             'test/documentation-content/labs/latest',
-            'test/documentation-content/apps-manager/1.0',
+            'test/documentation-content/test-toolkit/1.0',
         ],
     }];
 }

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -15,6 +15,7 @@ const repoUrls = new Map([
     ['cloud', 'https://github.com/bonitasoft/bonita-cloud-doc.git'],
     ['labs', 'https://github.com/bonitasoft/bonita-labs-doc.git'],
     ['test-toolkit', 'https://github.com/bonitasoft/bonita-test-toolkit-doc.git'],
+    ['apps-manager', 'https://github.com/bonitasoft/bonita-apps-manager-doc.git'],
 ]);
 function getRepoUrl(componentName) {
     const repoUrl = repoUrls.get(componentName);
@@ -116,6 +117,7 @@ else if (useTestSources) {
             'test/documentation-content/cloud/latest',
             'test/documentation-content/test-toolkit/1.0',
             'test/documentation-content/labs/latest',
+            'test/documentation-content/apps-manager/1.0',
         ],
     }];
 }

--- a/test/documentation-content/apps-manager/1.0/antora.yml
+++ b/test/documentation-content/apps-manager/1.0/antora.yml
@@ -1,6 +1,6 @@
 name: apps-manager
 title: Bonita Apps Manager
-version: 1.0
+version: '1.0'
 prerelease: .alpha-01
 start_page: ROOT:index.adoc
 asciidoc:

--- a/test/documentation-content/apps-manager/1.0/antora.yml
+++ b/test/documentation-content/apps-manager/1.0/antora.yml
@@ -1,0 +1,12 @@
+name: apps-manager
+title: Bonita Apps Manager
+version: 1.0
+prerelease: .alpha-01
+start_page: ROOT:index.adoc
+asciidoc:
+  attributes:
+    # page attributes
+    page-editable: true
+
+nav:
+  - modules/ROOT/taxonomy.adoc

--- a/test/documentation-content/apps-manager/1.0/modules/ROOT/pages/index.adoc
+++ b/test/documentation-content/apps-manager/1.0/modules/ROOT/pages/index.adoc
@@ -1,0 +1,3 @@
+= Home version
+
+I am the home of {page-component-title} {page-component-version}

--- a/test/documentation-content/apps-manager/1.0/modules/ROOT/pages/page-01.adoc
+++ b/test/documentation-content/apps-manager/1.0/modules/ROOT/pages/page-01.adoc
@@ -1,0 +1,2 @@
+= Page 01
+:page-aliases: old-page-01.adoc

--- a/test/documentation-content/apps-manager/1.0/modules/ROOT/taxonomy.adoc
+++ b/test/documentation-content/apps-manager/1.0/modules/ROOT/taxonomy.adoc
@@ -1,0 +1,2 @@
+* Apps manager
+** xref:page-01.adoc[Page 01]


### PR DESCRIPTION
* Only add Apps-manager-documentation on preview script
* We will add this component on "production" site only when the real name is choosing