### PR TITLE
feat: Update comment instead create and delete

### DIFF
--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -60,6 +60,7 @@ runs:
         result-encoding: string
     - name: Create or update comments
       if: ${{steps.changed-files.outputs.all_changed_files != ''}}
+      id: createUpdateComment
       uses: actions/github-script@v6
       env:
         LINKS: ${{steps.set-result.outputs.result}}
@@ -68,5 +69,5 @@ runs:
       with:
         script: |
           const script = require('./bds/.github/actions/comment-pr-with-links/comments-with-url-links.js');
-          await script.createOrUpdateComments({github, context})
+          return await script.createOrUpdateComments({github, context})
         result-encoding: string

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -69,7 +69,5 @@ runs:
       with:
         script: |
           const script = require('./bds/.github/actions/comment-pr-with-links/comments-with-url-links.js');
-          let commentId = await script.createOrUpdateComments({github, context});
-          console.log('commentId',commentId);
-          return commentId;
+          return await script.createOrUpdateComments({github, context});
         result-encoding: string

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -69,5 +69,7 @@ runs:
       with:
         script: |
           const script = require('./bds/.github/actions/comment-pr-with-links/comments-with-url-links.js');
-          return await script.createOrUpdateComments({github, context})
+          let commentId = await script.createOrUpdateComments({github, context});
+          console.log('commentId',commentId);
+          return commentId;
         result-encoding: string

--- a/.github/actions/comment-pr-with-links/github.js
+++ b/.github/actions/comment-pr-with-links/github.js
@@ -9,8 +9,7 @@ module.exports = {
             if (comment.body?.startsWith(template)) {
                 return {
                     exists: true,
-                    id: comment.id,
-                    body: comment.body
+                    id: comment.id
                 };
             }
         }

--- a/.github/actions/comment-pr-with-links/github.js
+++ b/.github/actions/comment-pr-with-links/github.js
@@ -10,6 +10,7 @@ module.exports = {
                 return {
                     exists: true,
                     id: comment.id,
+                    body: comment.body
                 };
             }
         }
@@ -17,15 +18,26 @@ module.exports = {
         return {
             exists: false,
             id: null,
+            body: ''
         };
     },
     createComment: async function ({github, context, body}) {
-        await github.rest.issues.createComment({
+        const comment = await github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: body
         })
+        return comment?.id;
+    },
+    updateComment: async function ({github, context, body, comment_id}) {
+        const comment = await github.rest.issues.updateComment({
+            comment_id: comment_id,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: body
+        })
+        return comment?.id;
     },
     deleteComment: async function ({github, context, commentIdToDelete}) {
         await github.rest.issues.deleteComment({


### PR DESCRIPTION
Since [this commit](https://github.com/bonitasoft/bonita-documentation-site/commit/c1190dab578dbd3931ce6b122e867f01b77d13de), we list the page edited to check in a comment to help the reviewer.
However in the first iteration we create and delete oldest comment at each triggered workflow.

With this PR, we just update the oldest comment if it's exist.