### PR TITLE
ci(action): add deleted/renamed url in comment

### DIFF
--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -51,20 +51,18 @@ runs:
       id: set-result
       env:
         FILES: ${{steps.changed-files.outputs.all_changed_files}}
+        DELETED: ${{steps.changed-files.outputs.deleted_files}}
         SITE_URL: ${{ inputs.site-url }}
         COMPONENT_NAME: ${{ inputs.component-name }}
       with:
         script: |
           const script = require('./bds/.github/actions/comment-pr-with-links/comments-with-url-links.js');
           return await script.prepareUrlLinks({github, context});
-        result-encoding: string
     - name: Create or update comments
       if: ${{steps.changed-files.outputs.all_changed_files != ''}}
-      id: createUpdateComment
       uses: actions/github-script@v6
       env:
         LINKS: ${{steps.set-result.outputs.result}}
-        RENAMED_FILES: ${{steps.changed-files.outputs.renamed_files}}
         HAS_DELETED_FILES: ${{steps.changed-files.outputs.any_deleted}}
       with:
         script: |

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -12,7 +12,7 @@ inputs:
   pattern:
     description: ''
     required: false
-    default: 'modules/**'
+    default: 'modules/**/*.adoc'
   # needed by content repository (default master) and here (computed automagically)
   doc-site-branch:
     description: 'The branch of the `bonita-documentation-site` used to download js files'

--- a/.github/actions/comment-pr-with-links/comments-with-url-links.js
+++ b/.github/actions/comment-pr-with-links/comments-with-url-links.js
@@ -33,10 +33,14 @@ function buildMessage({header, links, hasWarningMessage}) {
     const preface =
         'In order to merge this pull request, you need to check your updates with the following url.\n\n';
 
-    const availableLinks = `### :mag: Page list: \n ${links.updated}\n\n\n`;
+    const availableLinks = `### :mag: Updated pages 
+    The following pages were updated, please ensure that the display is correct: 
+    ${links.updated}\n\n`;
     let warningAliasMessage = '';
     if (hasWarningMessage) {
-        warningAliasMessage = `### :warning: Alias \n At least one page has been renamed, moved or deleted in the Pull Request. Make sure to add [aliases](https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc#use-alias-to-create-redirects) and verify if this following link redirect in the right place \n ${links?.deleted}`
+        warningAliasMessage = `### :warning: Check redirects
+         At least one page has been renamed, moved or deleted in the Pull Request. Make sure to add [aliases](https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc#use-alias-to-create-redirects) and verify hat the following links redirect to the right location: 
+         ${links?.deleted}`
     }
 
     return template + header + preface + availableLinks + warningAliasMessage;

--- a/.github/actions/comment-pr-with-links/comments-with-url-links.js
+++ b/.github/actions/comment-pr-with-links/comments-with-url-links.js
@@ -30,19 +30,18 @@ module.exports = {
 };
 
 function buildMessage({header, links, hasWarningMessage}) {
-    const preface =
-        'In order to merge this pull request, you need to check your updates with the following url.\n\n';
+    const preface = 'In order to merge this pull request, you need to check your updates with the following url.\n\n';
 
     const availableLinks = `### :mag: Updated pages 
-    The following pages were updated, please ensure that the display is correct: 
-    ${links.updated}
+The following pages were updated, please ensure that the display is correct:
+${links.updated}
 `;
     let warningAliasMessage = '';
     if (hasWarningMessage) {
         warningAliasMessage = `
-         ### :warning: Check redirects
-         At least one page has been renamed, moved or deleted in the Pull Request. Make sure to add [aliases](https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc#use-alias-to-create-redirects) and verify that the following links redirect to the right location: 
-         ${links?.deleted}`
+### :warning: Check redirects
+At least one page has been renamed, moved or deleted in the Pull Request. Make sure to add [aliases](https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc#use-alias-to-create-redirects) and verify that the following links redirect to the right location:          
+${links?.deleted}`
     }
 
     return template + header + preface + availableLinks + warningAliasMessage;

--- a/.github/actions/comment-pr-with-links/comments-with-url-links.js
+++ b/.github/actions/comment-pr-with-links/comments-with-url-links.js
@@ -1,51 +1,56 @@
 const githubUtils = require('./github');
-const templateCommentId= '<!-- previewLinksCheck-->\n';
+const template = '<!-- previewLinksCheck-->\n';
 module.exports = {
-    prepareUrlLinks:  async function ({github, context}) {
-            let {FILES, SITE_URL, COMPONENT_NAME} = process.env;
-            const {data: pr} = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                pull_number: context.issue.number,
-                repo: context.repo.repo,
-            });
-            let files = FILES.split(' ');
-            let urls = [];
-            files.forEach(file => {
-                const splitted = file.split('/');
-                splitted.shift();
-                const pageName = splitted.pop();
-                const moduleName = splitted.shift();
-                let url = `${SITE_URL}/${COMPONENT_NAME}/${pr.base.ref}${moduleName === 'ROOT' ? '/' : `/${moduleName}/`}${pageName?.split('.').shift()}`;
-                urls.push(`- [ ] [${moduleName}/${pageName}](${url})`);
-            });
-            return urls.join('\n');
+    prepareUrlLinks: async function ({github, context}) {
+        let {FILES,DELETED, SITE_URL, COMPONENT_NAME} = process.env;
+        const {data: pr} = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            pull_number: context.issue.number,
+            repo: context.repo.repo,
+        });
+        let result = {};
+        result.updated = prepareLinks({files: FILES.split(' '), siteUrl: SITE_URL, component: COMPONENT_NAME, branch: pr.base.ref});
+        result.deleted = prepareLinks({files: DELETED.split(' '), siteUrl: SITE_URL, component: COMPONENT_NAME, branch: pr.base.ref});
+        return result;
     },
-    createOrUpdateComments: async function ({github,context}){
-        let {LINKS, RENAMED_FILES, HAS_DELETED_FILES} = process.env;
-        const header='## :memo: Check the pages that have been modified\n\n';
-        let body = buildMessage(header,LINKS,HAS_DELETED_FILES === 'true' || RENAMED_FILES != '');
-        const {exists, id} = await githubUtils.isCommentExist({github,context,template: templateCommentId});
+    createOrUpdateComments: async function ({github, context}) {
+        let {LINKS, HAS_DELETED_FILES} = process.env;
+        const header = '## :memo: Check the pages that have been modified \n\n';
+        let links = JSON.parse(LINKS);
+        let body = buildMessage({header, links ,hasWarningMessage : (HAS_DELETED_FILES === 'true')});
+        const {exists, id} = await githubUtils.isCommentExist({github, context, template});
         // Delete oldest comment if another comments exist
-        if (exists && id){
-            await githubUtils.updateComment({github,context,comment_id: id, body});
+        if (exists && id) {
+            await githubUtils.updateComment({github, context, comment_id: id, body});
             return id;
         }
-        const comment = await githubUtils.createComment({github,context, body});
+        const comment = await githubUtils.createComment({github, context, body});
         return comment?.id;
     }
-
 };
 
-function buildMessage(header,links,hasWarningMessage){
+function buildMessage({header, links, hasWarningMessage}) {
     const preface =
         'In order to merge this pull request, you need to check your updates with the following url.\n\n';
 
-    const availableLinks = `### :mag: Page list: \n ${links}\n\n\n\n`;
-
+    const availableLinks = `### :mag: Page list: \n ${links.updated}\n\n\n`;
     let warningAliasMessage = '';
-    if(hasWarningMessage){
-        warningAliasMessage='\n \n ### :warning: At least one page has been deleted in the Pull Request. Make sure to add [aliases](https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc#use-alias-to-create-redirects)'
+    if (hasWarningMessage) {
+        warningAliasMessage = `### :warning: Alias \n At least one page has been renamed, moved or deleted in the Pull Request. Make sure to add [aliases](https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc#use-alias-to-create-redirects) and verify if this following link redirect in the right place \n ${links?.deleted}`
     }
 
-    return templateCommentId + header + preface + availableLinks + warningAliasMessage;
+    return template + header + preface + availableLinks + warningAliasMessage;
+}
+
+function prepareLinks({files, siteUrl, component, branch}) {
+    let preparedLinks = [];
+    files.forEach(file => {
+        const splitPath = file.split('/');
+        splitPath.shift();
+        const pageName = splitPath.pop();
+        const moduleName = splitPath.shift();
+        let url = `${siteUrl}/${component}/${branch}${moduleName === 'ROOT' ? '/' : `/${moduleName}/`}${pageName?.split('.').shift()}`;
+        preparedLinks.push(`- [ ] [${moduleName}/${pageName}](${url})`);
+    });
+    return preparedLinks.join('\n');
 }

--- a/.github/actions/comment-pr-with-links/comments-with-url-links.js
+++ b/.github/actions/comment-pr-with-links/comments-with-url-links.js
@@ -35,11 +35,13 @@ function buildMessage({header, links, hasWarningMessage}) {
 
     const availableLinks = `### :mag: Updated pages 
     The following pages were updated, please ensure that the display is correct: 
-    ${links.updated}\n\n`;
+    ${links.updated}
+`;
     let warningAliasMessage = '';
     if (hasWarningMessage) {
-        warningAliasMessage = `### :warning: Check redirects
-         At least one page has been renamed, moved or deleted in the Pull Request. Make sure to add [aliases](https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc#use-alias-to-create-redirects) and verify hat the following links redirect to the right location: 
+        warningAliasMessage = `
+         ### :warning: Check redirects
+         At least one page has been renamed, moved or deleted in the Pull Request. Make sure to add [aliases](https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc#use-alias-to-create-redirects) and verify that the following links redirect to the right location: 
          ${links?.deleted}`
     }
 


### PR DESCRIPTION
Improve the action that manages the PR comment about the details of the preview which is deployed to Surge:
* List deleted/renamed URL (on GitHub, a renamed file is detected as deleted and created with a new name)
* URL could be used to check if alias is exist and functional
* Only notify changes about AsciiDoc files (don't consider images for instance)

closes #463