### PR TITLE
ci: validate the branch name of the pull request

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -27,14 +27,13 @@ inputs:
 
 runs:
   using: "composite"
-  env:
-    # TODO use everywhere
-    BRANCH_NAME: ${{ github.head_ref }}
   steps:
     # TODO extract in a dedicated action and use it in the build-pr-site action as well
     - name: Validate branch name
       if: github.event.action != 'closed'
       uses: actions/github-script@v6
+      env:
+        BRANCH_NAME: ${{ github.head_ref }}
       with:
         script: |
           const { BRANCH_NAME } = process.env

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -40,9 +40,9 @@ runs:
         const pattern = '^[\/a-zA-Z0-9._-]+$';
         if (!nameMatchesPattern(branchName, pattern)) {
           core.setFailed(
-            `The branch name ${branchName} does not match the predefined regex pattern - ${pattern}. This branch wouldn't be used by Antora to build the preview
-So there would be missing content and side effects.
-For more details, see https://github.com/bonitasoft/bonita-documentation-site/issues/512.`
+            `The branch name ${branchName} does not match the predefined regex pattern - ${pattern}. This branch wouldn't be used by Antora to build the preview.g
+            So there would be missing content and side effects.
+            For more details, see https://github.com/bonitasoft/bonita-documentation-site/issues/512.`
           );
         }
 

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -28,6 +28,24 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # TODO extract in a dedicated action and use it in the build-pr-site action as well
+    - name: Validate branch name
+      if: github.event.action != 'closed'
+      uses: actions/github-script@v6
+      with:
+        script: |
+        // inspired from https://github.com/goshencollege/validate-branch-name/blob/v1.0.1/index.js
+        const branchName = github.context.payload.ref.replace("refs/heads/", "");
+        // only allow backslash, alphanumeric, dot, underscore and dash
+        const pattern = '^[\/a-zA-Z0-9._-]+$';
+        if (!nameMatchesPattern(branchName, pattern)) {
+          core.setFailed(
+            `The branch name ${branchName} does not match the predefined regex pattern - ${pattern}. This branch wouldn't be used by Antora to build the preview
+So there would be missing content and side effects.
+For more details, see https://github.com/bonitasoft/bonita-documentation-site/issues/512.`
+          );
+        }
+
     - uses: bonitasoft/actions/packages/surge-preview-tools@v2
       id: surge-preview-tools
       with:

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -32,17 +32,15 @@ runs:
     - name: Validate branch name
       if: github.event.action != 'closed'
       uses: actions/github-script@v6
-      env:
-        BRANCH_NAME: ${{ github.head_ref }}
       with:
         script: |
-          const { BRANCH_NAME } = process.env
+          const branchName = process.env.GITHUB_HEAD_REF;
           // inspired from https://github.com/goshencollege/validate-branch-name/blob/v1.0.1/index.js
           // only allow backslash, alphanumeric, dot, underscore and dash
           const pattern = '^[\/a-zA-Z0-9._-]+$';
-          if (!new RegExp(pattern).test(BRANCH_NAME)) {
+          if (!new RegExp(pattern).test(branchName)) {
             core.setFailed(
-              `The branch name ${BRANCH_NAME} does not match the predefined regex pattern: ${pattern}.
+              `The branch name ${branchName} does not match the predefined regex pattern: ${pattern}.
               This branch wouldn't be used by Antora to build the preview.
               So there would be missing content and side effects.
               For more details, see https://github.com/bonitasoft/bonita-documentation-site/issues/512.`

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -27,6 +27,9 @@ inputs:
 
 runs:
   using: "composite"
+  env:
+    # TODO use everywhere
+    BRANCH_NAME: ${{ github.head_ref }}
   steps:
     # TODO extract in a dedicated action and use it in the build-pr-site action as well
     - name: Validate branch name
@@ -34,16 +37,17 @@ runs:
       uses: actions/github-script@v6
       with:
         script: |
+          const { BRANCH_NAME } = process.env
           // inspired from https://github.com/goshencollege/validate-branch-name/blob/v1.0.1/index.js
-          const branchName = context.ref.replace("refs/heads/", "");
-          console.info('branchName', branchName);
+          //const BRANCH_NAME = context.payload..replace("refs/heads/", "");
+          console.info('BRANCH_NAME', BRANCH_NAME);
           // only allow backslash, alphanumeric, dot, underscore and dash
           const pattern = '^[\/a-zA-Z0-9._-]+$';
           console.info('pattern', pattern);
-          if (!new RegExp(pattern).test(branchName)) {
-            console.info('Detected NON matching pattern', branchName);
+          if (!new RegExp(pattern).test(BRANCH_NAME)) {
+            console.info('Detected NON matching pattern', BRANCH_NAME);
             core.setFailed(
-              `The branch name ${branchName} does not match the predefined regex pattern: ${pattern}.
+              `The branch name ${BRANCH_NAME} does not match the predefined regex pattern: ${pattern}.
               This branch wouldn't be used by Antora to build the preview.g
               So there would be missing content and side effects.
               For more details, see https://github.com/bonitasoft/bonita-documentation-site/issues/512.`

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -44,7 +44,7 @@ runs:
     - name: Build Site without error check
       if: github.event.action != 'closed' && inputs.component-name != ''
       shell: bash
-      run: ./build-preview.bash --component ${{inputs.component-name}} --branch ${{ github.head_ref }} --ignore-error ${{inputs.ignore-errors}} --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+      run: ./build-preview.bash --component "${{inputs.component-name}}" --branch "${{ github.head_ref }}" --ignore-error "${{inputs.ignore-errors}}" --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: Build Site
       if: github.event.action != 'closed' && inputs.component-name == ''
       shell: bash

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -34,17 +34,17 @@ runs:
       uses: actions/github-script@v6
       with:
         script: |
-        // inspired from https://github.com/goshencollege/validate-branch-name/blob/v1.0.1/index.js
-        const branchName = github.context.payload.ref.replace("refs/heads/", "");
-        // only allow backslash, alphanumeric, dot, underscore and dash
-        const pattern = '^[\/a-zA-Z0-9._-]+$';
-        if (!nameMatchesPattern(branchName, pattern)) {
-          core.setFailed(
-            `The branch name ${branchName} does not match the predefined regex pattern - ${pattern}. This branch wouldn't be used by Antora to build the preview.g
-            So there would be missing content and side effects.
-            For more details, see https://github.com/bonitasoft/bonita-documentation-site/issues/512.`
-          );
-        }
+          // inspired from https://github.com/goshencollege/validate-branch-name/blob/v1.0.1/index.js
+          const branchName = github.context.payload.ref.replace("refs/heads/", "");
+          // only allow backslash, alphanumeric, dot, underscore and dash
+          const pattern = '^[\/a-zA-Z0-9._-]+$';
+          if (!nameMatchesPattern(branchName, pattern)) {
+            core.setFailed(
+              `The branch name ${branchName} does not match the predefined regex pattern - ${pattern}. This branch wouldn't be used by Antora to build the preview.g
+              So there would be missing content and side effects.
+              For more details, see https://github.com/bonitasoft/bonita-documentation-site/issues/512.`
+            );
+          }
 
     - uses: bonitasoft/actions/packages/surge-preview-tools@v2
       id: surge-preview-tools

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -28,35 +28,19 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # TODO extract in a dedicated action and use it in the build-pr-site action as well
-    - name: Validate branch name
-      if: github.event.action != 'closed'
-      uses: actions/github-script@v6
-      with:
-        script: |
-          const branchName = process.env.GITHUB_HEAD_REF;
-          // inspired from https://github.com/goshencollege/validate-branch-name/blob/v1.0.1/index.js
-          // only allow backslash, alphanumeric, dot, underscore and dash
-          const pattern = '^[\/a-zA-Z0-9._-]+$';
-          if (!new RegExp(pattern).test(branchName)) {
-            core.setFailed(
-              `The branch name ${branchName} does not match the predefined regex pattern: ${pattern}.
-              This branch wouldn't be used by Antora to build the preview.
-              So there would be missing content and side effects.
-              For more details, see https://github.com/bonitasoft/bonita-documentation-site/issues/512.`
-            );
-          }
-
-    - uses: bonitasoft/actions/packages/surge-preview-tools@v2
-      id: surge-preview-tools
-      with:
-        surge-token: ${{ inputs.surge-token }}
     - name: Checkout
       uses: actions/checkout@v3
       if: github.event.action != 'closed'
       with:
         repository: 'bonitasoft/bonita-documentation-site'
         ref: ${{ inputs.doc-site-branch }}
+    - name: Validate PR branch name
+      uses: ./.github/actions/validate-pr-branch-name
+      if: github.event.action != 'closed'
+    - uses: bonitasoft/actions/packages/surge-preview-tools@v2
+      id: surge-preview-tools
+      with:
+        surge-token: ${{ inputs.surge-token }}
     - name: Build Setup
       uses: ./.github/actions/build-setup
       if: github.event.action != 'closed'

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -35,7 +35,7 @@ runs:
       with:
         script: |
           // inspired from https://github.com/goshencollege/validate-branch-name/blob/v1.0.1/index.js
-          const branchName = github.context.payload.ref.replace("refs/heads/", "");
+          const branchName = context.ref.replace("refs/heads/", "");
           // only allow backslash, alphanumeric, dot, underscore and dash
           const pattern = '^[\/a-zA-Z0-9._-]+$';
           if (!nameMatchesPattern(branchName, pattern)) {

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -38,16 +38,12 @@ runs:
         script: |
           const { BRANCH_NAME } = process.env
           // inspired from https://github.com/goshencollege/validate-branch-name/blob/v1.0.1/index.js
-          //const BRANCH_NAME = context.payload..replace("refs/heads/", "");
-          console.info('BRANCH_NAME', BRANCH_NAME);
           // only allow backslash, alphanumeric, dot, underscore and dash
           const pattern = '^[\/a-zA-Z0-9._-]+$';
-          console.info('pattern', pattern);
           if (!new RegExp(pattern).test(BRANCH_NAME)) {
-            console.info('Detected NON matching pattern', BRANCH_NAME);
             core.setFailed(
               `The branch name ${BRANCH_NAME} does not match the predefined regex pattern: ${pattern}.
-              This branch wouldn't be used by Antora to build the preview.g
+              This branch wouldn't be used by Antora to build the preview.
               So there would be missing content and side effects.
               For more details, see https://github.com/bonitasoft/bonita-documentation-site/issues/512.`
             );

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -38,9 +38,10 @@ runs:
           const branchName = context.ref.replace("refs/heads/", "");
           // only allow backslash, alphanumeric, dot, underscore and dash
           const pattern = '^[\/a-zA-Z0-9._-]+$';
-          if (!nameMatchesPattern(branchName, pattern)) {
+          if (!new RegExp(pattern).test(branchName)) {
             core.setFailed(
-              `The branch name ${branchName} does not match the predefined regex pattern - ${pattern}. This branch wouldn't be used by Antora to build the preview.g
+              `The branch name ${branchName} does not match the predefined regex pattern: ${pattern}.
+              This branch wouldn't be used by Antora to build the preview.g
               So there would be missing content and side effects.
               For more details, see https://github.com/bonitasoft/bonita-documentation-site/issues/512.`
             );

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -36,9 +36,12 @@ runs:
         script: |
           // inspired from https://github.com/goshencollege/validate-branch-name/blob/v1.0.1/index.js
           const branchName = context.ref.replace("refs/heads/", "");
+          console.info('branchName', branchName);
           // only allow backslash, alphanumeric, dot, underscore and dash
           const pattern = '^[\/a-zA-Z0-9._-]+$';
+          console.info('pattern', pattern);
           if (!new RegExp(pattern).test(branchName)) {
+            console.info('Detected NON matching pattern', branchName);
             core.setFailed(
               `The branch name ${branchName} does not match the predefined regex pattern: ${pattern}.
               This branch wouldn't be used by Antora to build the preview.g

--- a/.github/actions/build-pr-site/action.yml
+++ b/.github/actions/build-pr-site/action.yml
@@ -19,6 +19,8 @@ runs:
       with:
         repository: 'bonitasoft/bonita-documentation-site'
         ref: ${{ inputs.doc-site-branch }}
+    - name: Validate PR branch name
+      uses: ./.github/actions/validate-pr-branch-name
     - name: Build Setup
       uses: ./.github/actions/build-setup
     - name: Build Site

--- a/.github/actions/validate-pr-branch-name/action.yml
+++ b/.github/actions/validate-pr-branch-name/action.yml
@@ -1,0 +1,22 @@
+name: 'Validate the PR branch name'
+description: 'Ensure that the branch match a pattern that works with Antora'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate branch name
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const branchName = process.env.GITHUB_HEAD_REF;
+          // inspired from https://github.com/goshencollege/validate-branch-name/blob/v1.0.1/index.js
+          // only allow backslash, alphanumeric, dot, underscore and dash
+          const pattern = '^[\/a-zA-Z0-9._-]+$';
+          if (!new RegExp(pattern).test(branchName)) {
+            core.setFailed(
+              `The branch name ${branchName} does not match the predefined regex pattern: ${pattern}.
+              This branch wouldn't be used by Antora to build the preview.
+              So there would be missing content and side effects.
+              For more details, see https://github.com/bonitasoft/bonita-documentation-site/issues/512.`
+            );
+          }

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -105,7 +105,6 @@ else if (useTestSources) {
         url: './',
         branches: ['HEAD'],
         start_paths: [
-            'test/documentation-content/central/1.0',
             'test/documentation-content/bcd/3.4',
             'test/documentation-content/bcd/3.5',
             'test/documentation-content/bonita/v0',
@@ -115,6 +114,7 @@ else if (useTestSources) {
             'test/documentation-content/bonita/v2021.2',
             'test/documentation-content/bonita/v2022.1-beta',
             'test/documentation-content/bonita/v2022.2-alpha',
+            'test/documentation-content/central/1.0',
             'test/documentation-content/cloud/latest',
             'test/documentation-content/labs/latest',
             'test/documentation-content/test-toolkit/1.0',


### PR DESCRIPTION
Both the PR preview and build-site action now validates the name of the branch of the Pull Request.
Antora seems not using the branch when it contains special characters like parentheses. This introduces side effects that make the preview unusable (no content) and validation may failed.
As this is hard to diagnose by documentation content contributors, fail the workflow run if the PR branch is not valid for Antora and display an explicit error message.

Also escape all parameters passed to the `build-preview.bash` script to
avoid syntax error when it is executed.

closes #512 

### Tests

This PR has been tested with the PR which detected the issue: https://github.com/bonitasoft/bonita-doc/pull/2309

The rexep has been tested with https://extendsclass.com/regex/a3fe16a
It maches

- fixMyProblem
- docs_elements
- feat-875
- docs/basic_release-7.8.2

It doesn't match

- fixPb_for_whatever(65.2)_or_{something_else}_perhaps
- fixPb{()


### Notes

The run of the "Publish PR preview " workflow for this PR fails but this is not due to the changes introduced here.
This occurs after the surge publish when the workflow tries to detected documentation content changes.
See #511
```
Run tj-actions/glob@v16
  with:
    files: modules/**/*.adoc
    files-separator: 
    excluded-files-separator: 
    files-from-source-file-separator: 
    excluded-files-from-source-file-separator: 
    follow-symbolic-links: true
    match-directories: true
    match-gitignore-files: false
    separator:  
    escape-paths: false
    strip-top-level-dir: true
    include-deleted-files: false
    base-ref: master
    head-repo-fork: false
    sha: e11da9eb90fcb49de5b49f749462c979d9ad259a
    working-directory: .
  env:
    npm_config_cache: /home/runner/.npm
Error: No paths found using the specified patterns
```