### PR TITLE
ci(fix): update pattern for files preview comments

### DIFF
--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -12,7 +12,7 @@ inputs:
   pattern:
     description: ''
     required: false
-    default: 'modules/**/*.adoc'
+    default: '**/*.adoc'
   # needed by content repository (default master) and here (computed automagically)
   doc-site-branch:
     description: 'The branch of the `bonita-documentation-site` used to download js files'
@@ -30,18 +30,14 @@ runs:
       id: check-glob-pattern
       with:
         files: |
-          *
-        excluded-files: |
-          !${{inputs.pattern}}
+          ${{inputs.pattern}}
     - name: Get changed files in PR
       if: ${{ steps.check-glob-pattern.outputs.paths != ''}}
       id: changed-files
       uses: tj-actions/changed-files@v35
       with:
         files: |
-          *
-        files_ignore: |
-          !${{inputs.pattern}}
+          ${{inputs.pattern}}
     - name: Checkout
       uses: actions/checkout@v3
       if: ${{ github.event.action != 'closed' || steps.check-glob-pattern.outputs.paths != '' }}
@@ -51,7 +47,7 @@ runs:
         path: bds
     - name: Compute links to display
       uses: actions/github-script@v6
-      if: ${{steps.changed-files.outputs.all_changed_files != '' || steps.check-glob-pattern.outputs.paths != ''}}
+      if: ${{steps.changed-files.outputs.any_changed == 'true' || steps.check-glob-pattern.outputs.paths != ''}}
       id: set-result
       env:
         FILES: ${{steps.changed-files.outputs.all_changed_files}}
@@ -63,7 +59,7 @@ runs:
           const script = require('./bds/.github/actions/comment-pr-with-links/comments-with-url-links.js');
           return await script.prepareUrlLinks({github, context});
     - name: Create or update comments
-      if: ${{steps.changed-files.outputs.all_changed_files != ''  || steps.check-glob-pattern.outputs.paths != ''}}
+      if: ${{steps.changed-files.outputs.any_changed == 'true' || steps.check-glob-pattern.outputs.paths != ''}}
       uses: actions/github-script@v6
       env:
         LINKS: ${{steps.set-result.outputs.result}}

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -34,11 +34,26 @@ runs:
     - name: Get changed files in PR
       if: ${{ steps.check-glob-pattern.outputs.paths != ''}}
       id: changed-files
+      continue-on-error: true # we will verify the error in a later step
       uses: tj-actions/changed-files@v35
       with:
         files: |
           ${{inputs.pattern}}
+    - name: Check result
+      id: get-changed-files
+      uses: actions/github-script@v6
+      env:
+        DETECTION_STATUS: ${{steps.changed-files.outcome}}
+      with:
+        script: |
+          const {DETECTION_STATUS} = process.env;
+          core.info(`Outcome of the 'get-changed-files' step is: ${DETECTION_STATUS}`);
+          if(DETECTION_STATUS === 'failure') {
+            return 'false';
+          }
+          return 'true';
     - name: Log files changed
+      if: ${{steps.get-changed-files.outputs.result == 'true' }}
       shell: bash
       run: |
         echo "${{ steps.changed-files.outputs.all_changed_files }}"
@@ -51,7 +66,7 @@ runs:
         path: bds
     - name: Compute links to display
       uses: actions/github-script@v6
-      if: ${{steps.changed-files.outputs.any_changed == 'true' }}
+      if: ${{steps.get-changed-files.outputs.result == 'true' }}
       id: set-result
       env:
         FILES: ${{steps.changed-files.outputs.all_changed_files}}
@@ -63,7 +78,7 @@ runs:
           const script = require('./bds/.github/actions/comment-pr-with-links/comments-with-url-links.js');
           return await script.prepareUrlLinks({github, context});
     - name: Create or update comments
-      if: ${{steps.changed-files.outputs.any_changed == 'true' }}
+      if: ${{steps.get-changed-files.outputs.result == 'true' }}
       uses: actions/github-script@v6
       env:
         LINKS: ${{steps.set-result.outputs.result}}

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -30,24 +30,28 @@ runs:
       id: check-glob-pattern
       with:
         files: |
-          ${{inputs.pattern}}
+          *
+        excluded-files: |
+          !${{inputs.pattern}}
     - name: Get changed files in PR
       if: ${{ steps.check-glob-pattern.outputs.paths != ''}}
       id: changed-files
-      uses: tj-actions/changed-files@v34
+      uses: tj-actions/changed-files@v35
       with:
         files: |
-          ${{inputs.pattern}}
+          *
+        files_ignore: |
+          !${{inputs.pattern}}
     - name: Checkout
       uses: actions/checkout@v3
-      if: github.event.action != 'closed'
+      if: ${{ github.event.action != 'closed' || steps.check-glob-pattern.outputs.paths != '' }}
       with:
         repository: 'bonitasoft/bonita-documentation-site'
         ref: ${{ inputs.doc-site-branch }}
         path: bds
     - name: Compute links to display
       uses: actions/github-script@v6
-      if: ${{steps.changed-files.outputs.all_changed_files != ''}}
+      if: ${{steps.changed-files.outputs.all_changed_files != '' || steps.check-glob-pattern.outputs.paths != ''}}
       id: set-result
       env:
         FILES: ${{steps.changed-files.outputs.all_changed_files}}
@@ -59,7 +63,7 @@ runs:
           const script = require('./bds/.github/actions/comment-pr-with-links/comments-with-url-links.js');
           return await script.prepareUrlLinks({github, context});
     - name: Create or update comments
-      if: ${{steps.changed-files.outputs.all_changed_files != ''}}
+      if: ${{steps.changed-files.outputs.all_changed_files != ''  || steps.check-glob-pattern.outputs.paths != ''}}
       uses: actions/github-script@v6
       env:
         LINKS: ${{steps.set-result.outputs.result}}

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -12,7 +12,7 @@ inputs:
   pattern:
     description: ''
     required: false
-    default: '**/*.adoc'
+    default: 'modules/**/*.adoc'
   # needed by content repository (default master) and here (computed automagically)
   doc-site-branch:
     description: 'The branch of the `bonita-documentation-site` used to download js files'

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -30,7 +30,9 @@ runs:
       id: check-glob-pattern
       with:
         files: |
-          ${{inputs.pattern}}
+          *
+        excluded-files: |
+          !${{inputs.pattern}}
     - name: Get changed files in PR
       if: ${{ steps.check-glob-pattern.outputs.paths != ''}}
       id: changed-files

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -30,9 +30,7 @@ runs:
       id: check-glob-pattern
       with:
         files: |
-          *
-        excluded-files: |
-          !${{inputs.pattern}}
+          ${{inputs.pattern}}
     - name: Get changed files in PR
       if: ${{ steps.check-glob-pattern.outputs.paths != ''}}
       id: changed-files
@@ -40,25 +38,20 @@ runs:
       with:
         files: |
           ${{inputs.pattern}}
-    - name: Log files update
+    - name: Log files changed
       shell: bash
       run: |
-        echo "-------------------------------------------------------"        
-        echo "glob-pattern {{ steps.check-glob-pattern.outputs.paths != '' }}"
-        echo "if {{steps.changed-files.outputs.any_changed == 'true' || steps.check-glob-pattern.outputs.paths != ''}}"
-        echo "all_changed_files ### ${{ steps.changed-files.outputs.all_changed_files }}"
-        echo "Boolean ### ${{steps.changed-files.outputs.all_changed_files != ''}}"
-        echo "Boolean ### ${{steps.changed-files.outputs.any_changed == 'true'}}"
+        echo "${{ steps.changed-files.outputs.all_changed_files }}"
     - name: Checkout
       uses: actions/checkout@v3
-      if: ${{ github.event.action != 'closed' || steps.check-glob-pattern.outputs.paths != '' }}
+      if: ${{ github.event.action != 'closed' }}
       with:
         repository: 'bonitasoft/bonita-documentation-site'
         ref: ${{ inputs.doc-site-branch }}
         path: bds
     - name: Compute links to display
       uses: actions/github-script@v6
-      if: ${{steps.changed-files.outputs.any_changed == 'true' || steps.check-glob-pattern.outputs.paths != ''}}
+      if: ${{steps.changed-files.outputs.any_changed == 'true' }}
       id: set-result
       env:
         FILES: ${{steps.changed-files.outputs.all_changed_files}}
@@ -70,7 +63,7 @@ runs:
           const script = require('./bds/.github/actions/comment-pr-with-links/comments-with-url-links.js');
           return await script.prepareUrlLinks({github, context});
     - name: Create or update comments
-      if: ${{steps.changed-files.outputs.any_changed == 'true' || steps.check-glob-pattern.outputs.paths != ''}}
+      if: ${{steps.changed-files.outputs.any_changed == 'true' }}
       uses: actions/github-script@v6
       env:
         LINKS: ${{steps.set-result.outputs.result}}

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -25,14 +25,7 @@ runs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
-    - name: Check if files pattern are valid
-      uses: tj-actions/glob@v16
-      id: check-glob-pattern
-      with:
-        files: |
-          ${{inputs.pattern}}
     - name: Get changed files in PR
-      if: ${{ steps.check-glob-pattern.outputs.paths != ''}}
       id: changed-files
       continue-on-error: true # we will verify the error in a later step
       uses: tj-actions/changed-files@v35

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -40,6 +40,15 @@ runs:
       with:
         files: |
           ${{inputs.pattern}}
+    - name: Log files update
+      shell: bash
+      run: |
+        echo "-------------------------------------------------------"        
+        echo "glob-pattern {{ steps.check-glob-pattern.outputs.paths != '' }}"
+        echo "if {{steps.changed-files.outputs.any_changed == 'true' || steps.check-glob-pattern.outputs.paths != ''}}"
+        echo "all_changed_files ### ${{ steps.changed-files.outputs.all_changed_files }}"
+        echo "Boolean ### ${{steps.changed-files.outputs.all_changed_files != ''}}"
+        echo "Boolean ### ${{steps.changed-files.outputs.any_changed == 'true'}}"
     - name: Checkout
       uses: actions/checkout@v3
       if: ${{ github.event.action != 'closed' || steps.check-glob-pattern.outputs.paths != '' }}

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -31,3 +31,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           doc-site-branch: ${{ github.head_ref }}
           build-preview-command: ./build-preview.bash --single-branch-per-repo --ignore-error true
+          pattern: 'tests/**/*.adoc'
+

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -31,5 +31,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           doc-site-branch: ${{ github.head_ref }}
           build-preview-command: ./build-preview.bash --single-branch-per-repo --ignore-error true
-          pattern: 'tests/**/*.adoc'
-

--- a/README.adoc
+++ b/README.adoc
@@ -21,6 +21,7 @@ image::https://github.com/bonitasoft/bonita-documentation-site/actions/workflows
 This repository lets you generate the Bonita documentation site. It uses {url-antora}[Antora] which processes {url-asciidoc}:[AsciiDoc]
 documentation content stored in various Git repositories.
 
+NOTE: This is an artificial changes to test the changes
 
 == Documentation
 


### PR DESCRIPTION
Before: When action is running when files doesn't match pattern the workflow is on error.
Now: We reverse the logic, and ignore file who doesn't respect the pattern given as input.

closes #511 