### PR TITLE
docs: improve the "contributors" documentation

### DIFF
--- a/docs/content/CONTRIBUTING.adoc
+++ b/docs/content/CONTRIBUTING.adoc
@@ -36,10 +36,10 @@ NOTE: This metadata information is useful to improve our visibility for search e
 
 == Short presentation of the documentation environment
 
-https://docs.asciidoctor.org/asciidoc/latest/[Asciidoc] is the markup language chosen to write our documentation content.
-You can check the official documentation site to learn more on Asciidoc syntax.
+https://docs.asciidoctor.org/asciidoc/latest/[AsciiDoc] is the markup language chosen to write our documentation content.
+You can check the official documentation site to learn more on AsciiDoc syntax.
 
-If you know the Markdown syntax, please check the https://docs.asciidoctor.org/asciidoc/latest/asciidoc-vs-markdown[Asciidoc vs Markdown]
+If you know the Markdown syntax, please check the https://docs.asciidoctor.org/asciidoc/latest/asciidoc-vs-markdown[AsciiDoc vs Markdown]
 documentation comparison to speedup the learning.
 
 We are using https://docs.antora.org/[Antora] to generate the Bonita documentation.
@@ -66,8 +66,8 @@ in the infrastructure (increase bill)
 
 === Variables and attributes
 
-You can define asciidoc attributes in the `antora.yml` file at repository root and reference it in content page.
-For a detailed documentation about attributes, see the https://docs.asciidoctor.org/asciidoc/latest/attributes/attribute-entry-substitutions/[asciidoc attribute documentation].
+You can define AsciiDoc attributes in the `antora.yml` file at repository root and reference it in content page.
+For a detailed documentation about attributes, see the https://docs.asciidoctor.org/asciidoc/latest/attributes/attribute-entry-substitutions/[AsciiDoc attribute documentation].
 
 [source,yml]
 ----

--- a/docs/content/CONTRIBUTING.adoc
+++ b/docs/content/CONTRIBUTING.adoc
@@ -109,6 +109,21 @@ This configuration then let parts like `<version>${bonita.version}</version>` no
 
 It is also possible to configure substitution globally for the block (see the documentation).
 
+
+=== Bonita editions admonitions
+
+When Bonita editions are referenced, to avoid different wording, the following rules should apply:
+
+* Use an admonition Note (see https://bonitasoft.github.io/bonita-documentation-theme/admonitions.html)
+* Nothing if the feature is Community
+* "For Subscription editions only" if available in Teamwork, Efficiency, Performance, and Enterprise editions
+* "For Efficiency, Performance, and Enterprise editions only" if Subscription but not Teamwork
+* "For Performance and Enterprise editions only" if any
+* "For Enterprise edition only" if any
+
+
+== Tips about the files organization
+
 === Antora modules
 
 You can use Antora modules to clarify content (for instance, getting-started guides, how-to articles). +
@@ -247,15 +262,3 @@ The syntax is described in {url-antora-docs}/navigation/reference-resources/ (it
 Antora 3 provides a new syntax for referencing attachments. See {url-antora-docs}/navigation/reference-resources/ +
 Please prefer this syntax when Antora 3 will be used to build the site: it allows detecting broken references because it uses the `xref` macro.
 ====
-
-=== Bonita editions admonitions
-
-When Bonita editions are referenced, to avoid different wording, the following rules should apply:
-
-* Use an admonition Note (see https://bonitasoft.github.io/bonita-documentation-theme/admonitions.html)
-* Nothing if the feature is Community
-* "For Subscription editions only" if available in Teamwork, Efficiency, Performance, and Enterprise editions
-* "For Efficiency, Performance, and Enterprise editions only" if Subscription but not Teamwork
-* "For Performance and Enterprise editions only" if any
-* "For Enterprise edition only" if any
-

--- a/docs/content/CONTRIBUTING.adoc
+++ b/docs/content/CONTRIBUTING.adoc
@@ -124,6 +124,26 @@ When Bonita editions are referenced, to avoid different wording, the following r
 
 == Tips about the files organization
 
+=== File names
+
+Always follow the https://en.wikipedia.org/wiki/Letter_case#Kebab_case[kebab case] convention. This is something we are going to progressively enforce in all repositories, for consistency and to improve the SEO.
+
+Do not prefix the file name with the name of the component (file are already stored in a dedicated component repository, the url already contains the component key) or a category (use Antora module instead to organize the content - see the next paragraph). 
+
+Do
+
+* my-super-page.adoc
+* explicit-architecture.png
+* nav-bonita-installation.adoc
+
+Don't
+
+* bc-app-declaration.adoc (component prefix and abbreviation): application-declaration.adoc 
+* BC_archi_single.png (both component prefix and underscore): archi-single.png 
+
+NOTE: examples involving `bc` are taken from https://github.com/bonitasoft/bonita-central-doc/pull/9/files[bonita-central-doc PR #9]
+
+
 === Antora modules
 
 You can use Antora modules to clarify content (for instance, getting-started guides, how-to articles). +

--- a/docs/content/CONTRIBUTING.adoc
+++ b/docs/content/CONTRIBUTING.adoc
@@ -139,7 +139,9 @@ Do
 Don't
 
 * bc-app-declaration.adoc (component prefix and abbreviation): application-declaration.adoc 
-* BC_archi_single.png (both component prefix and underscore): archi-single.png 
+* BC_archi_single.png (both component prefix and underscore): archi-single.png
+* livingapp_manage_configuration.adoc (module and underscore): manage-configuration.adoc in the living-app or living-application module (from the https://github.com/bonitasoft/bonita-continuous-delivery-doc/blob/c6ff1bba6449857aff4898ea52af7678653ceee7/modules/ROOT/pages/livingapp_manage_configuration.adoc[bcd component])
+* Service_Level_Agreement_Data_Management.adoc (module and underscore and uppercase): data-management.adoc in a service-level-agreement or sla module (from the https://github.com/bonitasoft/bonita-cloud-doc/blob/338e54e9dd60b1ef62fcffe60134a2db01d0923b/modules/ROOT/pages/Service_Level_Agreement_Data_Management.adoc[cloud component])
 
 NOTE: examples involving `bc` are taken from https://github.com/bonitasoft/bonita-central-doc/pull/9/files[bonita-central-doc PR #9]
 

--- a/docs/documentation-components-and-versions.adoc
+++ b/docs/documentation-components-and-versions.adoc
@@ -46,7 +46,7 @@ GA release (actions to be performed detailed later in this document):
 
 === How to integrate a new component
 
-NOTE
+[NOTE]
 ====
 This is a brief overview of all required actions. +
 For a complete list of required tasks, see the https://bonitasoft.atlassian.net/wiki/spaces/BS/pages/22503227439/How-to+configure+a+new+documentation+content+component[complete guide] (restricted access).

--- a/docs/documentation-components-and-versions.adoc
+++ b/docs/documentation-components-and-versions.adoc
@@ -46,35 +46,20 @@ GA release (actions to be performed detailed later in this document):
 
 === How to integrate a new component
 
+NOTE
+====
+This is a brief overview of all required actions. +
+For a complete list of required tasks, see the https://bonitasoft.atlassian.net/wiki/spaces/BS/pages/22503227439/How-to+configure+a+new+documentation+content+component[complete guide] (restricted access).
+====
+
 To add a new component, you first need to create a GitHub repository which will contain the asciidoc sources of this component
 (i.e. the documentation content). This repository must be organized according to the {url-antora-docs}/organize-content-files/[Antora recommendations].
 You can check existing repositories for working examples.
 At minimum, it will contain an `antora.yml` file at its root
 
-[source,yml]
-----
-name: componentName
-title: yourTitle
-version: yourVersion
-asciidoc:
- attributes:
-  # define here attributes you need to templatize the documentation content or the html generation
-nav:
-- modules/ROOT/taxonomy.adoc
-----
-
-IMPORTANT: Choose the `component name` carefully as it will be an element of the url that is visible to readers. It will identify the component everywhere in the documentation (for instance, to create cross component xrefs)
-
 You should also add the GitHub workflows (PR preview, push to production, ...). Check existing components for a source of inspiration.
 
-Then, you need to add a new source in the https://github.com/bonitasoft/bonita-documentation-site/blob/master/antora-playbook.yml[Antora playbook].
-A source references the URL of the repository and all the branches to retrieve. +
-Also update the https://github.com/bonitasoft/bonita-documentation-site/blob/master/scripts/generate-content-for-preview-antora-playbook.js[preview script] to reference the component by its name: it will be used to
-
-* generate the previews of documentation content PR in the new repository
-* identify push to production related to content change in the component
-
-Finally, update the <<docsearch-configuration, DocSearch configuration>> to make this component searchable.
+Also update the https://github.com/bonitasoft/bonita-documentation-site/blob/master/scripts/generate-content-for-preview-antora-playbook.js[preview script] to reference the component by its name.
 
 
 === How to integrate a new version of an existing component

--- a/docs/documentation-components-and-versions.adoc
+++ b/docs/documentation-components-and-versions.adoc
@@ -41,22 +41,6 @@ GA release (actions to be performed detailed later in this document):
 * archive the oldest version
 * mark the 5th version as out of support: On new Bonita Platform GA release, an old version is considered as out of support.
 
-== DocSearch and component versions
-
-=== Don't use Antora component without version
-
-No version Antora component: {url-antora-docs}/component-with-no-version/
-
-The documentation site search crawling and widget we have setup, require a component and a version. In case of version less
-components, there is no version token in the url, so this defeats the mechanism in place.
-
-See https://github.com/bonitasoft/bonita-labs-doc/pull/127#discussion_r585309113 for extra information.
-
-[[docsearch-configuration]]
-=== DocSearch configuration
-
-The configuration is available in the https://crawler.algolia.com/admin/crawlers[DocSearch crawler admin page (restricted access)].
-
 
 == General how-to for components and versions management
 


### PR DESCRIPTION
Introduce a new "Tips about the files organization" paragraph that includes the existing "Antora module" section and a new section about "file names".
Simplify the "component version" paragraphs: they were hard to follow and lacks of details. Only keep general information.