### PR TITLE
chore: remove bonita 7.8 version

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -26,7 +26,6 @@ content:
     - url: https://github.com/bonitasoft/bonita-doc.git
       branches:
         - "archives"
-        - "7.8"
         - "7.9"
         - "7.10"
         - "7.11"

--- a/netlify.toml
+++ b/netlify.toml
@@ -64,6 +64,9 @@ to = "/bonita/2021.1/:splat"
 # Bonita Old Documentation redirects to Archives
 ########################################
 # Add a new entry when archiving a version
+[[redirects]]
+from = "/bonita/7.8/*"
+to = "/bonita/latest/:splat"
 
 [[redirects]]
 from = "/bonita/7.7/*"


### PR DESCRIPTION
Since bonita 2021.1 is out-of-support, we remove the latest version from site and generate static documentation for 7.8

Theses PR should be merged before this documentation-site PR.
- [x] 2021.1 no more propagated: #535 merge the PR prior merging the others
- [x] Documentation content: https://github.com/bonitasoft/bonita-doc/pull/2342
- [x]  Rest-documentation-site update: https://github.com/bonitasoft/bonita-rest-documentation-site/pull/19
- [x]  Archived Bonita 7.8 https://github.com/bonitasoft/bonita-doc/pull/2343


:heavy_check_mark: Default branch on bonita-doc is now 2021.2
:heavy_check_mark: Algolia config is updated to remove 7.8