### PR TITLE
chore: stop propagating the content from bonita 2021.1

### DIFF
--- a/scripts/propagate_doc_upwards.bash
+++ b/scripts/propagate_doc_upwards.bash
@@ -48,7 +48,6 @@ log "Configuration: REPO_NAME=${REPO_NAME}"
 git config merge.ours.driver true
 
 if [ "${REPO_NAME}" == "bonita-doc" ]; then
-  merge "2021.1" "2021.2"
   merge "2021.2" "2022.1"
   merge "2022.1" "2022.2"
   merge "2022.2" "2023.1"


### PR DESCRIPTION
This version is now out of support.