### PR TITLE
feat(bcd): enable bcd 4 doc deployment

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -40,9 +40,8 @@ content:
         - "master"
     - url: https://github.com/bonitasoft/bonita-continuous-delivery-doc.git
       branches:
-        - "3.4"
-        - "3.5"
         - "3.6"
+        - "4.0"
     - url: https://github.com/bonitasoft/bonita-test-toolkit-doc.git
       branches:
         - "1.0"

--- a/netlify.toml
+++ b/netlify.toml
@@ -159,6 +159,14 @@ to = "/bcd/latest/"
 
 # Archives
 [[redirects]]
+from = "/bcd/3.5/*"
+to = "/bcd/latest/:splat"
+
+[[redirects]]
+from = "/bcd/3.4/*"
+to = "/bcd/latest/:splat"
+
+[[redirects]]
 from = "/bcd/3.3/*"
 to = "/bcd/latest/:splat"
 


### PR DESCRIPTION
Remove obsole BCD versions and publish BCD 4.

(To be merged once the target BCD doc content is ready)