### PR TITLE
feat: handle antora prerelease boolean attribute

### DIFF
--- a/lib/antora/versions-sorter-extension.js
+++ b/lib/antora/versions-sorter-extension.js
@@ -28,15 +28,15 @@ module.exports.register = function () {
     })
 
     /**
-     * Return true if a version is defined as alpha in its version name or prerelease info.
+     * Return `true` if a version is defined as alpha in its display version or prerelease properties.
      * @param version The version object like one from component.versions array
      */
     function isAlpha(version){
         const explicitPrerelease = version.prerelease
-        const res = (typeof explicitPrerelease === "string" && explicitPrerelease.includes('alpha'))
-                || (version.version.includes('alpha'))
-        //logger.info(`version ${version.version} is alpha: ${res}`)
-        return res
+        return (typeof explicitPrerelease === "string" && explicitPrerelease.toLowerCase().includes('alpha'))
+          // "alpha" should not be included in the 'display_version' attribute but in the 'prerelease' attribute
+          // this is just a fallback to keep the order consistent
+          || (version.displayVersion.toLowerCase().includes('alpha'))
     }
 
     // hack, log as info, but logs are only produced if the debug level is enable (avoid function duplication)

--- a/lib/antora/versions-sorter-extension.js
+++ b/lib/antora/versions-sorter-extension.js
@@ -33,6 +33,7 @@ module.exports.register = function () {
      */
     function isAlpha(version){
         const explicitPrerelease = version.prerelease
+        // 'prerelease' can be a boolean. It can be used to mark as a pre-release but without specifying it is an alpha or beta version.
         return (typeof explicitPrerelease === "string" && explicitPrerelease.toLowerCase().includes('alpha'))
           // "alpha" should not be included in the 'display_version' attribute but in the 'prerelease' attribute
           // this is just a fallback to keep the order consistent

--- a/lib/antora/versions-sorter-extension.js
+++ b/lib/antora/versions-sorter-extension.js
@@ -15,7 +15,8 @@ module.exports.register = function () {
             const sortedVersions = [];
             const alphaVersions = [];
 
-            component.versions.forEach(version => version.prerelease?.includes('alpha') ? alphaVersions.push(version) : sortedVersions.push(version))
+            component.versions.forEach(version => isAlpha(version) ? alphaVersions.push(version) : sortedVersions.push(version))
+
             debugLogVersionsArray('Detected alpha versions', alphaVersions);
             sortedVersions.push(...alphaVersions);
             debugLogVersionsArray('Computed sorted versions', sortedVersions);
@@ -26,16 +27,28 @@ module.exports.register = function () {
         logComponentsVersions('Sort done', contentCatalog);
     })
 
+    /**
+     * Return true if a version is defined as alpha in its version name or prerelease info.
+     * @param version The version object like one from component.versions array
+     */
+    function isAlpha(version){
+        const explicitPrerelease = version.prerelease
+        const res = (typeof explicitPrerelease === "string" && explicitPrerelease.includes('alpha'))
+                || (version.version.includes('alpha'))
+        //logger.info(`version ${version.version} is alpha: ${res}`)
+        return res
+    }
+
     // hack, log as info, but logs are only produced if the debug level is enable (avoid function duplication)
     function debugLogVersionsArray(message, versions) {
-        if(!logger.isLevelEnabled('debug')) {
+        if (!logger.isLevelEnabled('debug')) {
             return;
         }
         logVersionsArray(message, versions);
     }
 
     function logVersionsArray(message, versions) {
-        if(!logger.isLevelEnabled('info')) {
+        if (!logger.isLevelEnabled('info')) {
             return;
         }
         logger.info(`${message} %o`, versions.map(v => {
@@ -47,7 +60,7 @@ module.exports.register = function () {
     }
 
     function logComponentsVersions(message, contentCatalog) {
-        if(!logger.isLevelEnabled('info')) {
+        if (!logger.isLevelEnabled('info')) {
             return;
         }
         logger.info(message);

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -118,6 +118,7 @@ else if (useTestSources) {
             'test/documentation-content/bonita/v2022.1-beta',
             'test/documentation-content/bonita/v2022.2-alpha',
             'test/documentation-content/central/1.0',
+            'test/documentation-content/central/2.0',
             'test/documentation-content/cloud/latest',
             'test/documentation-content/labs/latest',
             'test/documentation-content/test-toolkit/1.0',

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -107,6 +107,9 @@ else if (useTestSources) {
         start_paths: [
             'test/documentation-content/bcd/3.4',
             'test/documentation-content/bcd/3.5',
+            'test/documentation-content/bcd/4.0',
+            'test/documentation-content/bcd/4.1-alpha',
+            'test/documentation-content/bcd/4.2-alpha',
             'test/documentation-content/bonita/v0',
             'test/documentation-content/bonita/v7.4',
             'test/documentation-content/bonita/v7.11',

--- a/test/documentation-content/bcd/4.0/antora.yml
+++ b/test/documentation-content/bcd/4.0/antora.yml
@@ -1,0 +1,13 @@
+name: bcd
+title: Continuous Delivery
+# prerelease version but non alpha
+version: 4.0
+prerelease: true
+asciidoc:
+  attributes:
+    bcdVersion: '3.5.0' # latest available maintenance version
+    bonitaDocVersion: '2021.2'
+    # General site configuration
+    page-editable: true
+nav:
+  - modules/ROOT/taxonomy.adoc

--- a/test/documentation-content/bcd/4.0/antora.yml
+++ b/test/documentation-content/bcd/4.0/antora.yml
@@ -1,11 +1,11 @@
 name: bcd
 title: Continuous Delivery
+version: '4.0'
 # prerelease version but non alpha
-version: 4.0
 prerelease: true
 asciidoc:
   attributes:
-    bcdVersion: '3.5.0' # latest available maintenance version
+    bcdVersion: '4.0.0' # latest available maintenance version
     bonitaDocVersion: '2021.2'
     # General site configuration
     page-editable: true

--- a/test/documentation-content/bcd/4.0/modules/ROOT/pages/index.adoc
+++ b/test/documentation-content/bcd/4.0/modules/ROOT/pages/index.adoc
@@ -1,0 +1,6 @@
+= Home version
+
+I am the home of {page-component-title} {page-component-version}
+
+* BCD version: {bcdVersion}
+* Bonita Doc version: {bonitaDocVersion}

--- a/test/documentation-content/bcd/4.0/modules/ROOT/pages/page-01.adoc
+++ b/test/documentation-content/bcd/4.0/modules/ROOT/pages/page-01.adoc
@@ -1,0 +1,4 @@
+= Page 01
+:page-aliases: old-page-01.adoc
+
+Content

--- a/test/documentation-content/bcd/4.0/modules/ROOT/pages/page-02.adoc
+++ b/test/documentation-content/bcd/4.0/modules/ROOT/pages/page-02.adoc
@@ -1,0 +1,3 @@
+= Page 02
+
+Content

--- a/test/documentation-content/bcd/4.0/modules/ROOT/pages/page-03.adoc
+++ b/test/documentation-content/bcd/4.0/modules/ROOT/pages/page-03.adoc
@@ -1,0 +1,3 @@
+= Page 03
+
+Content

--- a/test/documentation-content/bcd/4.0/modules/ROOT/taxonomy.adoc
+++ b/test/documentation-content/bcd/4.0/modules/ROOT/taxonomy.adoc
@@ -1,0 +1,4 @@
+* BCD
+** xref:page-01.adoc[Page 01]
+** xref:page-02.adoc[Page 02]
+** xref:page-03.adoc[Page 03]

--- a/test/documentation-content/bcd/4.1-alpha/antora.yml
+++ b/test/documentation-content/bcd/4.1-alpha/antora.yml
@@ -1,0 +1,13 @@
+name: bcd
+title: Continuous Delivery
+# prerelease version and alpha
+version: 4.1-alpha
+prerelease: true
+asciidoc:
+  attributes:
+    bcdVersion: '3.5.0' # latest available maintenance version
+    bonitaDocVersion: '2021.2'
+    # General site configuration
+    page-editable: true
+nav:
+  - modules/ROOT/taxonomy.adoc

--- a/test/documentation-content/bcd/4.1-alpha/antora.yml
+++ b/test/documentation-content/bcd/4.1-alpha/antora.yml
@@ -1,13 +1,17 @@
 name: bcd
 title: Continuous Delivery
 # prerelease version and alpha
-version: 4.1-alpha
+version: 4.1
+# this is not how alpha suffix should be defined. It should be set in the prerelease attribute
+display_version: 4.1-alpha
 prerelease: true
 asciidoc:
   attributes:
-    bcdVersion: '3.5.0' # latest available maintenance version
+    bcdVersion: '4.1.0' # latest available maintenance version
     bonitaDocVersion: '2021.2'
     # General site configuration
-    page-editable: true
+    page-editable: false
+    page-next-release: true
+    page-hide-search-bar: true
 nav:
   - modules/ROOT/taxonomy.adoc

--- a/test/documentation-content/bcd/4.1-alpha/modules/ROOT/pages/index.adoc
+++ b/test/documentation-content/bcd/4.1-alpha/modules/ROOT/pages/index.adoc
@@ -1,0 +1,6 @@
+= Home version
+
+I am the home of {page-component-title} {page-component-version}
+
+* BCD version: {bcdVersion}
+* Bonita Doc version: {bonitaDocVersion}

--- a/test/documentation-content/bcd/4.1-alpha/modules/ROOT/pages/page-01.adoc
+++ b/test/documentation-content/bcd/4.1-alpha/modules/ROOT/pages/page-01.adoc
@@ -1,0 +1,4 @@
+= Page 01
+:page-aliases: old-page-01.adoc
+
+Content

--- a/test/documentation-content/bcd/4.1-alpha/modules/ROOT/pages/page-02.adoc
+++ b/test/documentation-content/bcd/4.1-alpha/modules/ROOT/pages/page-02.adoc
@@ -1,0 +1,3 @@
+= Page 02
+
+Content

--- a/test/documentation-content/bcd/4.1-alpha/modules/ROOT/pages/page-03.adoc
+++ b/test/documentation-content/bcd/4.1-alpha/modules/ROOT/pages/page-03.adoc
@@ -1,0 +1,3 @@
+= Page 03
+
+Content

--- a/test/documentation-content/bcd/4.1-alpha/modules/ROOT/taxonomy.adoc
+++ b/test/documentation-content/bcd/4.1-alpha/modules/ROOT/taxonomy.adoc
@@ -1,0 +1,4 @@
+* BCD
+** xref:page-01.adoc[Page 01]
+** xref:page-02.adoc[Page 02]
+** xref:page-03.adoc[Page 03]

--- a/test/documentation-content/bcd/4.2-alpha/antora.yml
+++ b/test/documentation-content/bcd/4.2-alpha/antora.yml
@@ -1,0 +1,12 @@
+name: bcd
+title: Continuous Delivery
+# non prerelease version BUT alpha
+version: 4.2-alpha
+asciidoc:
+  attributes:
+    bcdVersion: '3.5.0' # latest available maintenance version
+    bonitaDocVersion: '2021.2'
+    # General site configuration
+    page-editable: true
+nav:
+  - modules/ROOT/taxonomy.adoc

--- a/test/documentation-content/bcd/4.2-alpha/antora.yml
+++ b/test/documentation-content/bcd/4.2-alpha/antora.yml
@@ -1,12 +1,16 @@
 name: bcd
 title: Continuous Delivery
-# non prerelease version BUT alpha
-version: 4.2-alpha
+# non-prerelease version BUT alpha
+version: 4.2
+# this is not how alpha suffix should be defined. It should be set in the prerelease attribute
+display_version: 4.2-alpha
 asciidoc:
   attributes:
-    bcdVersion: '3.5.0' # latest available maintenance version
+    bcdVersion: '4.2.0' # latest available maintenance version
     bonitaDocVersion: '2021.2'
     # General site configuration
-    page-editable: true
+    page-editable: false
+    page-next-release: true
+    page-hide-search-bar: true
 nav:
   - modules/ROOT/taxonomy.adoc

--- a/test/documentation-content/bcd/4.2-alpha/modules/ROOT/pages/index.adoc
+++ b/test/documentation-content/bcd/4.2-alpha/modules/ROOT/pages/index.adoc
@@ -1,0 +1,6 @@
+= Home version
+
+I am the home of {page-component-title} {page-component-version}
+
+* BCD version: {bcdVersion}
+* Bonita Doc version: {bonitaDocVersion}

--- a/test/documentation-content/bcd/4.2-alpha/modules/ROOT/pages/page-01.adoc
+++ b/test/documentation-content/bcd/4.2-alpha/modules/ROOT/pages/page-01.adoc
@@ -1,0 +1,4 @@
+= Page 01
+:page-aliases: old-page-01.adoc
+
+Content

--- a/test/documentation-content/bcd/4.2-alpha/modules/ROOT/pages/page-02.adoc
+++ b/test/documentation-content/bcd/4.2-alpha/modules/ROOT/pages/page-02.adoc
@@ -1,0 +1,3 @@
+= Page 02
+
+Content

--- a/test/documentation-content/bcd/4.2-alpha/modules/ROOT/pages/page-03.adoc
+++ b/test/documentation-content/bcd/4.2-alpha/modules/ROOT/pages/page-03.adoc
@@ -1,0 +1,3 @@
+= Page 03
+
+Content

--- a/test/documentation-content/bcd/4.2-alpha/modules/ROOT/taxonomy.adoc
+++ b/test/documentation-content/bcd/4.2-alpha/modules/ROOT/taxonomy.adoc
@@ -1,0 +1,4 @@
+* BCD
+** xref:page-01.adoc[Page 01]
+** xref:page-02.adoc[Page 02]
+** xref:page-03.adoc[Page 03]

--- a/test/documentation-content/central/1.0/antora.yml
+++ b/test/documentation-content/central/1.0/antora.yml
@@ -1,12 +1,11 @@
 name: central
 title: Central
 version: '1.0'
-prerelease: .alpha-01
+prerelease: Beta
 start_page: ROOT:index.adoc
 asciidoc:
   attributes:
-    # page attributes
+    # General site configuration
     page-editable: true
-
 nav:
   - modules/ROOT/taxonomy.adoc

--- a/test/documentation-content/central/2.0/antora.yml
+++ b/test/documentation-content/central/2.0/antora.yml
@@ -1,0 +1,13 @@
+name: central
+title: Central
+version: '2.0'
+prerelease: Alpha
+start_page: ROOT:index.adoc
+asciidoc:
+  attributes:
+    # General site configuration
+    page-editable: false
+    page-next-release: true
+    page-hide-search-bar: true
+nav:
+  - modules/ROOT/taxonomy.adoc

--- a/test/documentation-content/central/2.0/antora.yml
+++ b/test/documentation-content/central/2.0/antora.yml
@@ -1,6 +1,7 @@
 name: central
 title: Central
 version: '2.0'
+# to check that the "alpha version detection" ignores case
 prerelease: Alpha
 start_page: ROOT:index.adoc
 asciidoc:

--- a/test/documentation-content/central/2.0/modules/ROOT/pages/index.adoc
+++ b/test/documentation-content/central/2.0/modules/ROOT/pages/index.adoc
@@ -1,0 +1,3 @@
+= Home version
+
+I am the home of {page-component-title} {page-component-version}

--- a/test/documentation-content/central/2.0/modules/ROOT/pages/page-01.adoc
+++ b/test/documentation-content/central/2.0/modules/ROOT/pages/page-01.adoc
@@ -1,0 +1,2 @@
+= Page 01
+:page-aliases: old-page-01.adoc

--- a/test/documentation-content/central/2.0/modules/ROOT/taxonomy.adoc
+++ b/test/documentation-content/central/2.0/modules/ROOT/taxonomy.adoc
@@ -1,0 +1,2 @@
+* Central
+** xref:page-01.adoc[Page 01]


### PR DESCRIPTION
Previously, the custom Antora extension that sort the versions (to put alpha versions at the end of the list) fails to manage boolean prerelease attributes. It expected to find a string.

In addition
- search for alpha in the "display version" . This is not the way it should be configured but acts as a backup
- ignore case when searching for alpha. This handles `2023.2 Alpha` as well.
- enrich the "test content resources" to  better "test" the new Antora extension implementation (add new component versions)

### Notes

This issue was spotted in https://github.com/bonitasoft/bonita-continuous-delivery-doc/pull/208