### PR TITLE
ci(push-production): fix slack configuration

### DIFF
--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -57,10 +57,9 @@ jobs:
         with:
           CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
           MESSAGE: |
-            :fire:  Propagating documentation upwards failed for repository *${{matrix.repo}}*. \n \n  
-            @channel *We need someone* ! \n  
-            - Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required) \n 
-            - Add a :sweat_drops: when it’s done (and eventually a :party_parrot: ) \n \n
+            :fire:  Propagating documentation upwards failed for repository *${{matrix.repo}}*.
+            @channel *We need someone*!
+            - Add a :fire_extinguisher:if you take the action to resolve the conflicts (only one person is required)
+            - Add a :sweat_drops: when it’s done (and eventually a :party_parrot:)
             More details on solving the conflicts locally <https://bonitasoft.atlassian.net/wiki/spaces/BS/pages/1181483014/Bonita+documentation+site+content+update#Bonita| there>
-        env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
The slack token was not correctly passed to the slack action (env variable instead of an action input).
The message has been reworked to be correctly displayed on Slack. 

closes #563

### Notes

Full investigation and test of the fix done in 
The issue was introduced when switching to the `bonitasoft/actions` in #518