### PR TITLE
ci: update workflows and github token permissions

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -66,10 +66,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: ${{ env.deploy_message }}
           netlify-config-path: ./netlify.toml
+          # let us detect when secrets are not available when attempting to push to production
+          fails-without-credentials: true
           github-deployment-description: ${{ env.deploy_message }}
-          # no comment, we only publish to production, github commit status and environment are set correctly
+          # no comment nor commit status, we only publish to production, the publishing information is available with the github environment
           enable-pull-request-comment: false
           enable-commit-comment: false
+          enable-commit-status: false
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/update-theme-bundle.yml
+++ b/.github/workflows/update-theme-bundle.yml
@@ -13,6 +13,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # push branch
+      pull-requests: write # Create the Pull Request
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This update lets reduce the GITHUB_TOKEN default permissions to READ:
- publish to production: no need to update the commit status with a deployment status information. In addition, the GH Token didn't have the permission to update the commit status. Some errors were displayed in the GH Actions logs
- update theme bundle: give write permissions to create the PR


### Notes

documentation of the actions that miss some permissions
- create-pull-request: update-theme-bundle: give write permissions to create the PR
- netlify: https://github.com/nwtgck/actions-netlify#optional-inputs