### PR TITLE
feat: Adding Atlas extension

### DIFF
--- a/.github/workflows/publish-production.yml
+++ b/.github/workflows/publish-production.yml
@@ -44,6 +44,8 @@ jobs:
         uses: ./.github/actions/build-setup
       - name: Build site
         run: GOOGLE_ANALYTICS_KEY=${{env.GOOGLE_ANALYTICS_KEY}} npm run build
+      - name: Prepare site manifest
+        run: gzip build/site/site-manifest.json
       - name: List the content of the generated site
         uses: ./.github/actions/log-built-site-details
       - name: Create deploy message if no component defined

--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,7 @@ ifdef::env-github[]
 endif::[]
 // External URIs:
 :url-antora: https://antora.org
-:url-antora-docs: https://docs.antora.org/antora/3.0
+:url-antora-docs: https://docs.antora.org/antora/3.1
 :url-asciidoc: https://docs.asciidoctor.org/asciidoc/latest/
 :url-node: https://nodejs.org
 :url-nvm: https://github.com/creationix/nvm
@@ -115,12 +115,24 @@ Then, this custom playbook is passed to the Antora CLI along with specific optio
 [[content-cache]]
 ===== Documentation content cache
 
-By default, without passing any specific options to the CLI relating to the documentation content, the sources are fetched
-from the remote Git repositories (GitHub) and cached (`.cache` directory).
+By default, without passing any specific options to the CLI relating to the documentation content, the resources are only fetched
+once from the remote locations and then cached in the `.cache` directory.
 
 WARNING: This cache is not updated except if you specify it to the CLI by passing the `--fetch-sources` option.
 
-You may need to update the cache if you want to retrieve a fresher version of the content (for instance, to get new branches related to new versions).
+You may need to update the cache if you want to retrieve a fresher version of the content. For instance, to get new branches related to new documentation versions,
+or newer content of existing versions.
+
+Resources put in the cache:
+
+* documentation content git repository
+* ui-bundles (Bonita and default themes)
+* Antora Atlas site manifest (use to validate xrefs)
+
+For more details, see:
+
+* {url-antora-docs}/page/cache/[Configure Antora’s Cache]
+* https://gitlab.com/antora/antora-atlas-extension#user-content-configure[Antora Atlas configuration]
 
 [[local-content]]
 ===== Using local documentation content repositories
@@ -140,6 +152,8 @@ used by the Bonita documentation.
 For instance:
 ----
 root
+  |
+  -- bonita-central-doc
   |
   -- bonita-cloud-doc
   |

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -53,9 +53,11 @@ ui:
     url: https://github.com/bonitasoft/bonita-documentation-theme/releases/download/v1.15.0/bonita-documentation-theme-v1.15.0.zip
 
 antora:
+  # IMPORTANT: use the 'require' syntax to ensure that the preview script is able to always update the configuration
   extensions:
     - require: ./lib/antora/versions-sorter-extension.js
     - require: ./lib/antora/versions-alias-extension.js
+    - require: '@antora/atlas-extension'
 
 asciidoc:
   # Only enable for preview, we don't care for production, and it can have performance impacts

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
+        "@antora/atlas-extension": "1.0.0-alpha.1",
         "antora": "3.1.4",
         "fs-extra": "~11.1.1",
         "js-yaml": "~4.1.0",
@@ -26,6 +27,21 @@
         "@antora/logger": "3.1.4",
         "@antora/user-require-helper": "~2.0",
         "@asciidoctor/core": "~2.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@antora/atlas-extension": {
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@antora/atlas-extension/-/atlas-extension-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-zbgUFNyc2V5Zuykj67nGAGGlTdNOLOQDy7DxoTVilAfj7s2J0qAL6WAs1O/PJPSpZqNxLFNFXsSmMYbEtlWftg==",
+      "dev": true,
+      "dependencies": {
+        "@antora/expand-path-helper": "~2.0",
+        "cache-directory": "~2.0",
+        "node-gzip": "~1.1",
+        "simple-get": "~4.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -16572,6 +16588,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/node-gzip": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/node-gzip/-/node-gzip-1.1.2.tgz",
+      "integrity": "sha512-ZB6zWpfZHGtxZnPMrJSKHVPrRjURoUzaDbLFj3VO70mpLTW5np96vXyHwft4Id0o+PYIzgDkBUjIzaNHhQ8srw==",
+      "dev": true
+    },
     "node_modules/normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -17852,6 +17874,18 @@
         "@antora/logger": "3.1.4",
         "@antora/user-require-helper": "~2.0",
         "@asciidoctor/core": "~2.2"
+      }
+    },
+    "@antora/atlas-extension": {
+      "version": "1.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@antora/atlas-extension/-/atlas-extension-1.0.0-alpha.1.tgz",
+      "integrity": "sha512-zbgUFNyc2V5Zuykj67nGAGGlTdNOLOQDy7DxoTVilAfj7s2J0qAL6WAs1O/PJPSpZqNxLFNFXsSmMYbEtlWftg==",
+      "dev": true,
+      "requires": {
+        "@antora/expand-path-helper": "~2.0",
+        "cache-directory": "~2.0",
+        "node-gzip": "~1.1",
+        "simple-get": "~4.0"
       }
     },
     "@antora/cli": {
@@ -30207,6 +30241,12 @@
           }
         }
       }
+    },
+    "node-gzip": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/node-gzip/-/node-gzip-1.1.2.tgz",
+      "integrity": "sha512-ZB6zWpfZHGtxZnPMrJSKHVPrRjURoUzaDbLFj3VO70mpLTW5np96vXyHwft4Id0o+PYIzgDkBUjIzaNHhQ8srw==",
+      "dev": true
     },
     "normalize-path": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "serve": "netlify dev -d build/site --debug --port 8080"
   },
   "devDependencies": {
+    "@antora/atlas-extension": "1.0.0-alpha.1",
     "antora": "3.1.4",
     "fs-extra": "~11.1.1",
     "js-yaml": "~4.1.0",


### PR DESCRIPTION
* We used the Atlas extension to generate a site-manifest.json. This file will be zipped and pushed to the same place as the site.
* In the next step, we want to use these files to validate the xref linked in the content

This PR is inspired by https://github.com/bonitasoft/bonita-documentation-site/pull/575.