### PR TITLE
refactor(preview-script): fix typo in `ignore-errors`

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -47,11 +47,26 @@ runs:
     - name: Build Site without error check
       if: github.event.action != 'closed' && inputs.component-name != ''
       shell: bash
-      run: ./build-preview.bash --component "${{inputs.component-name}}" --branch "${{ github.head_ref }}" --ignore-errors "${{inputs.ignore-errors}}" --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+      # '>' Replace newlines with spaces (folded)
+      # '-' No newline at end (strip)
+      run: >-
+        ./build-preview.bash
+        --branch "${{ github.head_ref }}"
+        --component "${{inputs.component-name}}"
+        --fetch-sources true
+        --ignore-errors "${{inputs.ignore-errors}}"
+        --pr "${{ github.event.pull_request.number }}"
+        --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: Build Site
       if: github.event.action != 'closed' && inputs.component-name == ''
       shell: bash
-      run: ${{ inputs.build-preview-command }} --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+      # '>' Replace newlines with spaces (folded)
+      # '-' No newline at end (strip)
+      run: >-
+        ${{ inputs.build-preview-command }}
+        --fetch-sources true
+        --pr "${{ github.event.pull_request.number }}"
+        --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: List the content of the generated site
       if: github.event.action != 'closed'
       uses: ./.github/actions/log-built-site-details

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: Build Site without error check
       if: github.event.action != 'closed' && inputs.component-name != ''
       shell: bash
-      run: ./build-preview.bash --component "${{inputs.component-name}}" --branch "${{ github.head_ref }}" --ignore-error "${{inputs.ignore-errors}}" --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
+      run: ./build-preview.bash --component "${{inputs.component-name}}" --branch "${{ github.head_ref }}" --ignore-errors "${{inputs.ignore-errors}}" --fetch-sources true --pr "${{ github.event.pull_request.number }}" --site-url "${{ steps.surge-preview-tools.outputs.preview-url }}"
     - name: Build Site
       if: github.event.action != 'closed' && inputs.component-name == ''
       shell: bash

--- a/.github/actions/build-pr-site/action.yml
+++ b/.github/actions/build-pr-site/action.yml
@@ -28,7 +28,12 @@ runs:
       run: npm install --save-dev antora@3.2.0-alpha.2
     - name: Build Site
       shell: bash
-      run: ${{ inputs.build-preview-command }} --fetch-sources true --pr "${{ github.event.pull_request.number }}"
+      # '>' Replace newlines with spaces (folded)
+      # '-' No newline at end (strip)
+      run: >-
+        ${{ inputs.build-preview-command }}
+        --fetch-sources true
+        --pr "${{ github.event.pull_request.number }}"
     - name: List the content of the generated site
       uses: ./.github/actions/log-built-site-details
     - name: Archive site

--- a/.github/workflows/generate-static-doc.yml
+++ b/.github/workflows/generate-static-doc.yml
@@ -26,8 +26,19 @@ jobs:
       - name: Build Setup
         uses: ./.github/actions/build-setup
       - name: Generate static documentation
-        run: |
-          ./build-preview.bash --branch "${{ github.event.inputs.branch }}" --component "${{ github.event.inputs.component }}" --fetch-sources true --site-title "${{ github.event.inputs.title }}" --type local --site-url DISABLED --hide-edit-page-links true --hide-navbar-components-list true
+        # '>' Replace newlines with spaces (folded)
+        # '-' No newline at end (strip)
+        run: >-
+          ./build-preview.bash
+          --branch "${{ github.event.inputs.branch }}"
+          --component "${{ github.event.inputs.component }}"
+          --fetch-sources true
+          --hide-edit-page-links true
+          --hide-navbar-components-list true
+          --ignore-errors true
+          --site-title "${{ github.event.inputs.title }}"
+          --site-url DISABLED
+          --type local
       - name: Zip docs
         if: (github.event.inputs.newRelease == 'true')
         run: |

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -31,7 +31,7 @@ jobs:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           doc-site-branch: ${{ github.head_ref }}
-          build-preview-command: ./build-preview.bash --single-branch-per-repo --ignore-error true
+          build-preview-command: ./build-preview.bash --single-branch-per-repo --ignore-errors true
   test:
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -31,7 +31,12 @@ jobs:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           doc-site-branch: ${{ github.head_ref }}
-          build-preview-command: ./build-preview.bash --single-branch-per-repo --ignore-errors true
+          # '>' Replace newlines with spaces (folded)
+          # '-' No newline at end (strip)
+          build-preview-command: >-
+            ./build-preview.bash
+            --ignore-errors true
+            --single-branch-per-repo
   test:
     runs-on: ubuntu-22.04
     permissions:
@@ -47,4 +52,10 @@ jobs:
           # here we check the
           #   - detailed logs of the Antora extensions
           #   - DocSearch integration
-          build-preview-command: ./build-preview.bash --use-test-sources --log-level debug --force-display-search-bar
+          # '>' Replace newlines with spaces (folded)
+          # '-' No newline at end (strip)
+          build-preview-command: >-
+            ./build-preview.bash
+            --force-display-search-bar
+            --log-level debug
+            --use-test-sources

--- a/build-preview.bash
+++ b/build-preview.bash
@@ -34,7 +34,7 @@ function usage() {
   echo "      --force-production-navbar               if the option is set, use the regular navbar instead of the preview one."
   echo "      --hide-edit-page-links <boolean>        'true': hide all edit page links (useful when generating documentation archive). Defaults to 'false'"
   echo "      --hide-navbar-components-list <boolean> 'true': hide components list in navbar. Defaults to 'false'"
-  echo "      --ignore-error <boolean>                If set to 'true', set 'failure_level' to 'info'. Otherwise, use the original value defined in the Antora playbook."
+  echo "      --ignore-errors <boolean>                If set to 'true', set 'failure_level' to 'info'. Otherwise, use the original value defined in the Antora playbook."
   echo "      --local-sources <boolean>               'true': use locally checkout sources in a working directory along the one of this project (useful to test local changes without push) , otherwise, use antora cache. Defaults to 'false'"
   echo "      --local-ui-bundle <boolean>             'true': use locally build ui bundle whose sources are in a working directory along the one of this project, otherwise, use antora cache. Defaults to 'false'"
   echo "      --log-level <level>                     Set the Antora log level. Defaults to the original value defined in the Antora playbook."

--- a/build-preview.bash
+++ b/build-preview.bash
@@ -34,7 +34,7 @@ function usage() {
   echo "      --force-production-navbar               if the option is set, use the regular navbar instead of the preview one."
   echo "      --hide-edit-page-links <boolean>        'true': hide all edit page links (useful when generating documentation archive). Defaults to 'false'"
   echo "      --hide-navbar-components-list <boolean> 'true': hide components list in navbar. Defaults to 'false'"
-  echo "      --ignore-errors <boolean>                If set to 'true', set 'failure_level' to 'info'. Otherwise, use the original value defined in the Antora playbook."
+  echo "      --ignore-errors <boolean>                If set to 'true', set the Antora 'failure_level' value to not fail the build if errors occur. Otherwise, use the original value defined in the Antora playbook."
   echo "      --local-sources <boolean>               'true': use locally checkout sources in a working directory along the one of this project (useful to test local changes without push) , otherwise, use antora cache. Defaults to 'false'"
   echo "      --local-ui-bundle <boolean>             'true': use locally build ui bundle whose sources are in a working directory along the one of this project, otherwise, use antora cache. Defaults to 'false'"
   echo "      --log-level <level>                     Set the Antora log level. Defaults to the original value defined in the Antora playbook."

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -218,10 +218,10 @@ if (logLevel) {
     doc.runtime.log.level = logLevel;
 }
 
-// Manage 'failure_level': if requested, set log level to info (default) to not break build for preview
-const ignoreError = getArgument(argv, 'ignore-error', false);
-if (ignoreError === 'true'){
-    delete doc.runtime.log.failure_level;
+// Manage 'failure_level': if requested, set log level to info to not break build for preview
+const ignoreErrors = getArgument(argv, 'ignore-errors', false);
+if (ignoreErrors === 'true'){
+    doc.runtime.log.failure_level = 'info';
 }
 
 

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -218,10 +218,10 @@ if (logLevel) {
     doc.runtime.log.level = logLevel;
 }
 
-// Manage 'failure_level': if requested, set log level to info to not break build for preview
+// Manage 'failure_level'
 const ignoreErrors = getArgument(argv, 'ignore-errors', false);
-if (ignoreErrors === 'true'){
-    doc.runtime.log.failure_level = 'info';
+if (ignoreErrors === 'true') {
+    doc.runtime.log.failure_level = 'fatal';
 }
 
 


### PR DESCRIPTION
Use plural for consistency with other options.
This option is not supposed to be used outside of this repository. The shared GitHub Actions provide a dedicated input which must be used instead of the script option. So, this change won't have side effects in workflow of the documentation content repositories.