### PR TITLE
ci: bump actions called in composite actions

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -33,7 +33,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: github.event.action != 'closed'
       with:
         repository: 'bonitasoft/bonita-documentation-site'

--- a/.github/actions/build-pr-site/action.yml
+++ b/.github/actions/build-pr-site/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: 'bonitasoft/bonita-documentation-site'
         ref: ${{ inputs.doc-site-branch }}

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         cache: 'npm'
         node-version-file: '.nvmrc'

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -34,7 +34,7 @@ runs:
           ${{inputs.pattern}}
     - name: Check result
       id: get-changed-files
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
         DETECTION_STATUS: ${{steps.changed-files.outcome}}
       with:
@@ -58,7 +58,7 @@ runs:
         ref: ${{ inputs.doc-site-branch }}
         path: bds
     - name: Compute links to display
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       if: ${{steps.get-changed-files.outputs.result == 'true' }}
       id: set-result
       env:
@@ -72,7 +72,7 @@ runs:
           return await script.prepareUrlLinks({github, context});
     - name: Create or update comments
       if: ${{steps.get-changed-files.outputs.result == 'true' }}
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       env:
         LINKS: ${{steps.set-result.outputs.result}}
         HAS_DELETED_FILES: ${{steps.changed-files.outputs.any_deleted}}

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Get changed files in PR
       id: changed-files
       continue-on-error: true # we will verify the error in a later step
-      uses: tj-actions/changed-files@v35
+      uses: tj-actions/changed-files@v40
       with:
         files: |
           ${{inputs.pattern}}

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
     - name: Get changed files in PR
@@ -51,7 +51,7 @@ runs:
       run: |
         echo "${{ steps.changed-files.outputs.all_changed_files }}"
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       if: ${{ github.event.action != 'closed' }}
       with:
         repository: 'bonitasoft/bonita-documentation-site'

--- a/.github/actions/validate-pr-branch-name/action.yml
+++ b/.github/actions/validate-pr-branch-name/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Validate branch name
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const branchName = process.env.GITHUB_HEAD_REF;


### PR DESCRIPTION
Bumped actions:
- actions/checkout: from v3 to v4
- actions/setup-node from v3 to v4
- actions/github-script v6 to v7
- tj-actions/changed-files from v35 to v40



### Discussions about `tj-actions/changed-files`

@benjaminParisel I know you are working on improving the report about changed files in PR, this bump may impact your work. Let's talk about this!
- v36 https://github.com/tj-actions/changed-files/blob/main/HISTORY.md#3600---2023-05-25
- v37 https://github.com/tj-actions/changed-files/blob/main/HISTORY.md#3700---2023-06-23
- v38 https://github.com/tj-actions/changed-files/blob/main/HISTORY.md#3800---2023-08-23
- v39 https://github.com/tj-actions/changed-files/blob/main/HISTORY.md#3900---2023-09-04
- v40 https://github.com/tj-actions/changed-files/blob/main/HISTORY.md#4000---2023-10-26

[ANSWER] yes, see https://github.com/bonitasoft/bonita-documentation-site/pull/621#issuecomment-1771230428.
The new action is https://github.com/bonitasoft/actions/tree/v2.3.0/packages/pr-antora-content-guidelines-checker