### PR TITLE
chore: make bonita 2021.2 an "out-of-support" version

### DIFF
--- a/scripts/propagate_doc_upwards.bash
+++ b/scripts/propagate_doc_upwards.bash
@@ -48,7 +48,6 @@ log "Configuration: REPO_NAME=${REPO_NAME}"
 git config merge.ours.driver true
 
 if [ "${REPO_NAME}" == "bonita-doc" ]; then
-  merge "2021.2" "2022.1"
   merge "2022.1" "2022.2"
   merge "2022.2" "2023.1"
   merge "2023.1" "2023.2"


### PR DESCRIPTION
* Remove content propagation for the 2021.2 version

Bonita-doc PR is ready [here](https://github.com/bonitasoft/bonita-doc/pull/2475)
