### PR TITLE
ci: use antora@3.2.0-alpha.3 when validating references

### DIFF
--- a/.github/actions/build-pr-site/action.yml
+++ b/.github/actions/build-pr-site/action.yml
@@ -29,7 +29,7 @@ runs:
       uses: ./.github/actions/build-setup
     - name: Install antora dependencies for xref validation
       shell: bash
-      run: npm install --save-dev antora@3.2.0-alpha.2
+      run: npm install --save-dev antora@3.2.0-alpha.3
     - name: Build Site
       shell: bash
       # '>' Replace newlines with spaces (folded)


### PR DESCRIPTION
Prepare the future by using the latest available alpha version.

### Notes

Changelog: https://gitlab.com/antora/antora/-/blob/main/CHANGELOG.adoc#3-2-0-alpha-3-2023-12-19
Relates to #652