### PR TITLE
ci: update the secrets used in workflows

### DIFF
--- a/.github/workflows/generate-static-doc.yml
+++ b/.github/workflows/generate-static-doc.yml
@@ -55,7 +55,7 @@ jobs:
           tag: ${{ github.event.inputs.branch }}-${{ env.timeStamp}}
           artifacts: "build/documentation-*"
           body: ${{ github.event.inputs.title }}
-          token: ${{ secrets.GH_PAT_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_DOC_TRIGGER_WF }}
       - name: archives-artefact
         if: (github.event.inputs.newRelease != 'true')
         uses: actions/upload-artifact@v4

--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: bonitasoft/${{ matrix.repo }}
-          token: ${{ secrets.GH_PAT_TOKEN }} # Dedicated token to have 'write permission' (we later push to this repository)
+          token: ${{ secrets.GH_TOKEN_DOC_TRIGGER_WF }} # Dedicated token to have 'write' and 'workflow' (needed to update workflows content) permissions (we later push to this repository)
           path: ./${{ matrix.repo }}
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: '0'


### PR DESCRIPTION
Use a token that has "workflow" permission when propagating documentation content.
This is required when updating the content of a workflow, otherwise an error occurs: `refusing to allow a Personal Access Token to create or update workflow '.github/workflows/push-content.yml' without 'workflow' scope`.
Use this token also in the "Generate static version" workflow to simplify maintenance (the token used here needs the same permissions).

### Notes

The formerly used token has been removed from the configuration and the secrets.
According to the GitHub search, the `GH_PAT_TOKEN` secret was only used in the 2 workflows updated in this PR.