### PR TITLE
ci: bump actions used in composite actions

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/README.md
+++ b/.github/actions/build-and-publish-pr-preview/README.md
@@ -4,4 +4,4 @@
 
 Manage the surge preview deployment. In particular, teardown the surge deployment when closing the Pull Request.
 
-If the site preview cannot be deployed, the site is uploaded as an artifact of the run.
+The site preview is always uploaded as an artifact of the workflow run to let test the preview locally.

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -28,11 +28,6 @@ inputs:
     description: 'If `true`, ignores Antora error. Only applies when the `component-name` input is set.'
     required: false
     default: 'true'
-  upload-artifact:
-    description: 'Only use for the documentation-site developments. Do not use externally, there is no guarantee of stability.'
-    required: false
-    type: boolean
-    default: true
 
 runs:
   using: "composite"
@@ -91,7 +86,7 @@ runs:
         teardown: true
         build: echo "site already built"
     - name: Archive site preview
-      if: github.event.action != 'closed' && inputs.upload-artifact == true
+      if: github.event.action != 'closed'
       uses: ./.github/actions/upload-pr-built-site-artifact
       with:
         site-type: preview

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -28,6 +28,11 @@ inputs:
     description: 'If `true`, ignores Antora error. Only applies when the `component-name` input is set.'
     required: false
     default: 'true'
+  upload-artifact:
+    description: 'Only use for the documentation-site developments. Do not use externally, there is no guarantee of stability.'
+    required: false
+    type: boolean
+    default: true
 
 runs:
   using: "composite"
@@ -86,7 +91,7 @@ runs:
         teardown: true
         build: echo "site already built"
     - name: Archive site preview
-      if: github.event.action != 'closed'
+      if: github.event.action != 'closed' && inputs.upload-artifact == true
       uses: ./.github/actions/upload-pr-built-site-artifact
       with:
         site-type: preview

--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -86,7 +86,7 @@ runs:
         teardown: true
         build: echo "site already built"
     - name: Archive site preview
-      if: github.event.action != 'closed' && steps.surge-preview-tools.outputs.can-run-surge-command != 'true'
+      if: github.event.action != 'closed'
       uses: ./.github/actions/upload-pr-built-site-artifact
       with:
         site-type: preview

--- a/.github/actions/comment-pr-with-links/action.yml
+++ b/.github/actions/comment-pr-with-links/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Get changed files in PR
       id: changed-files
       continue-on-error: true # we will verify the error in a later step
-      uses: tj-actions/changed-files@v40
+      uses: tj-actions/changed-files@v42
       with:
         files: |
           ${{inputs.pattern}}

--- a/.github/actions/upload-pr-built-site-artifact/action.yml
+++ b/.github/actions/upload-pr-built-site-artifact/action.yml
@@ -12,5 +12,7 @@ runs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        name: site-${{inputs.site-type}}-pr-${{github.event.pull_request.number}}-${{github.sha}}
+        # Include the job id to have a unique name if several jobs are run within the same workflow
+        # upload-artifact@v4 doesn't allow to upload several artifacts with the same name
+        name: site-${{inputs.site-type}}-pr-${{github.event.pull_request.number}}-${{github.sha}}-${{github.job}}
         path: build/site

--- a/.github/actions/upload-pr-built-site-artifact/action.yml
+++ b/.github/actions/upload-pr-built-site-artifact/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: site-${{inputs.site-type}}-pr-${{github.event.pull_request.number}}-${{github.sha}}
         path: build/site

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -50,6 +50,8 @@ jobs:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           doc-site-branch: ${{ github.head_ref }}
+          # we can only upload a single artifact with
+          upload-artifact: false
           # here we check the
           #   - detailed logs of the Antora extensions
           #   - DocSearch integration

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -50,8 +50,6 @@ jobs:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           doc-site-branch: ${{ github.head_ref }}
-          # we can only upload a single artifact with
-          upload-artifact: false
           # here we check the
           #   - detailed logs of the Antora extensions
           #   - DocSearch integration


### PR DESCRIPTION
Use the latest available and compatible versions
  - actions/upload-artifact v3 to v4
  - tj-actions/changed-files v40 to v42

This also ensures that the actions run with node 20 (remove warning about running actions with the deprecated Node 16 version).

In addition
  - always upload artifacts to be able to test locally by downloading the content of the preview.
  - postfix the name of the artifacts with the job id. This ensures to have unique name if the upload is done several times (name uniqueness is required by the new version of the upload-artifact action). This is needed for the doc-site PR as 2 previews are built (test and production contents)