### PR TITLE
test: hide some components in pages of bonita 2021.2

### DIFF
--- a/test/documentation-content/bonita/v2021.2/antora.yml
+++ b/test/documentation-content/bonita/v2021.2/antora.yml
@@ -12,7 +12,7 @@ asciidoc:
     # out of the box by the default UI and in bonita-theme
     page-pagination: true
     # hide some components in navbar and component/version selector
-    page-hide-components: bcd, labs
+    page-hide-components: bcd, labs, unknown-component
 nav:
   - modules/ROOT/taxonomy.adoc
   - modules/module-01/nav.adoc

--- a/test/documentation-content/bonita/v2021.2/antora.yml
+++ b/test/documentation-content/bonita/v2021.2/antora.yml
@@ -4,13 +4,15 @@ version: 2021.2
 start_page: ROOT:index.adoc
 asciidoc:
   attributes:
+    bonitaVersion: 2021.2
     page-editable: true
     page-out-of-support: false
     page-hide-search-bar: false # keep the `false` value to test the search on the 'latest' version
     page-navigation: true
     # out of the box by the default UI and in bonita-theme
     page-pagination: true
-    bonitaVersion: 2021.2
+    # hide some components in navbar and component/version selector
+    page-hide-components: bcd, labs
 nav:
   - modules/ROOT/taxonomy.adoc
   - modules/module-01/nav.adoc


### PR DESCRIPTION
**DISCLAIMER: this PR requires a new release of bonita-theme which includes https://github.com/bonitasoft/bonita-documentation-theme/pull/215**

Validate that the components can be hidden in navbar and in the component/version selector in all pages of a given component version.
This is done with a configuration in the component version descriptor.

Covers #689
Depends on https://github.com/bonitasoft/bonita-documentation-theme/pull/215