### PR TITLE
ci: bump bonitasoft/actions from v2 to v3

### DIFF
--- a/.github/actions/build-and-publish-pr-preview/action.yml
+++ b/.github/actions/build-and-publish-pr-preview/action.yml
@@ -41,7 +41,7 @@ runs:
     - name: Validate PR branch name
       uses: ./.github/actions/validate-pr-branch-name
       if: github.event.action != 'closed'
-    - uses: bonitasoft/actions/packages/surge-preview-tools@v2
+    - uses: bonitasoft/actions/packages/surge-preview-tools@v3
       id: surge-preview-tools
       with:
         surge-token: ${{ inputs.surge-token }}

--- a/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml
+++ b/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check
-        uses: bonitasoft/actions/packages/pr-antora-content-guidelines-checker@v2
+        uses: bonitasoft/actions/packages/pr-antora-content-guidelines-checker@v3
         with:
           attributes-to-check: ':description:'
           files-to-check: 'adoc'

--- a/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml
+++ b/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml
@@ -1,3 +1,7 @@
+# WARN: this workflow may be reused in other workflows triggered by a pull_request_target.
+# So, do not add steps that can be used as attack vectors.
+# See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ for more information.
+
 # Permissions required by this workflow that MUST be set in the calling workflow as this workflow can only downgrade permissions (https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow)
 # pull-requests: write / "pr-antora-content-guidelines-checker" write PR comments when the PR doesn't match the "Guidelines"
 name: Check Antora content guidelines in Pull Request

--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -12,4 +12,4 @@ jobs:
       pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
     steps:
       - name: Check Pull Request title
-        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v4


### PR DESCRIPTION
The actions in this new version run with Node 20.
This removes deprecation warning in the GH Actions logs.