### PR TITLE
ci: fix wrong action version in commit-message-check-format.yml

### DIFF
--- a/.github/workflows/commit-message-check-format.yml
+++ b/.github/workflows/commit-message-check-format.yml
@@ -12,4 +12,4 @@ jobs:
       pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
     steps:
       - name: Check Pull Request title
-        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v4
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v3


### PR DESCRIPTION
There is no v4 version at the moment, as this version was mistakenly defined instead of v3.