### PR TITLE
ci: introduce 2 workflows to manage the PR deployments

### DIFF
--- a/.github/workflows/surge-build-preview-site.yml
+++ b/.github/workflows/surge-build-preview-site.yml
@@ -16,6 +16,7 @@ on:
       - 'package.json'
       - 'package-lock.json'
 
+# TMP updated to trigger the workflow
 jobs:
   build-preview-site:
     uses: ./.github/workflows/_reusable_surge-build-preview.yml

--- a/.github/workflows/surge-build-preview-site.yml
+++ b/.github/workflows/surge-build-preview-site.yml
@@ -16,7 +16,6 @@ on:
       - 'package.json'
       - 'package-lock.json'
 
-# TMP updated to trigger the workflow
 jobs:
   build-preview-site:
     uses: ./.github/workflows/_reusable_surge-build-preview.yml

--- a/.github/workflows/surge-build-preview-test.yml
+++ b/.github/workflows/surge-build-preview-test.yml
@@ -17,6 +17,7 @@ on:
       - 'package.json'
       - 'package-lock.json'
 
+# TMP updated to trigger the workflow
 jobs:
   build-preview-test:
     uses: ./.github/workflows/_reusable_surge-build-preview.yml
@@ -32,5 +33,4 @@ jobs:
         --force-display-search-bar
         --log-level debug
         --use-test-sources
-      
       

--- a/.github/workflows/surge-build-preview-test.yml
+++ b/.github/workflows/surge-build-preview-test.yml
@@ -17,7 +17,6 @@ on:
       - 'package.json'
       - 'package-lock.json'
 
-# TMP updated to trigger the workflow
 jobs:
   build-preview-test:
     uses: ./.github/workflows/_reusable_surge-build-preview.yml
@@ -33,4 +32,3 @@ jobs:
         --force-display-search-bar
         --log-level debug
         --use-test-sources
-      

--- a/.github/workflows/surge-deploy-pr-preview-site.yml
+++ b/.github/workflows/surge-deploy-pr-preview-site.yml
@@ -1,17 +1,15 @@
-name: Deploy Surge preview
+name: Surge deploy - preview site
 
 on:
   workflow_run:
     workflows:
       - "Surge build - preview site"
-      - "Surge build - preview test"
     types:
       - completed
 
 jobs:
-  # TODO we cannot have a single workflow here
-  # the surge url is based on the job id, so if we want 2 deployments, we need 2 jobs, so in this case, one workflow per build workflow
-  deploy_surge_preview:
+  # MUST be unique across all surge preview deployments for a repository as the job id is used in the deployment URL
+  site:
     permissions:
       pull-requests: write # "afc163/surge-preview@v1" write PR comments when the PR is deployed
     uses: ./.github/workflows/_reusable_surge-deploy-preview.yml

--- a/.github/workflows/surge-deploy-pr-preview-test.yml
+++ b/.github/workflows/surge-deploy-pr-preview-test.yml
@@ -1,0 +1,16 @@
+name: Surge deploy - preview test
+
+on:
+  workflow_run:
+    workflows:
+      - "Surge build - preview test"
+    types:
+      - completed
+
+jobs:
+  # MUST be unique across all surge preview deployments for a repository as the job id is used in the deployment URL
+  test:
+    permissions:
+      pull-requests: write # "afc163/surge-preview@v1" write PR comments when the PR is deployed
+    uses: ./.github/workflows/_reusable_surge-deploy-preview.yml
+    secrets: inherit

--- a/.github/workflows/surge-deploy-pr-preview.yml
+++ b/.github/workflows/surge-deploy-pr-preview.yml
@@ -9,6 +9,8 @@ on:
       - completed
 
 jobs:
+  # TODO we cannot have a single workflow here
+  # the surge url is based on the job id, so if we want 2 deployments, we need 2 jobs, so in this case, one workflow per build workflow
   deploy_surge_preview:
     permissions:
       pull-requests: write # "afc163/surge-preview@v1" write PR comments when the PR is deployed


### PR DESCRIPTION
Previously, there was a single workflow to deploy 2 PR previews.
But the deployment URL depends on the job id, so the 2 deployments were done with the same URL whereas they should have their own.

Covers #686
Covers #700
