### PR TITLE
ci: make PR surge deployments work with both site and test

### DIFF
--- a/.github/workflows/_reusable_surge-deploy-preview.yml
+++ b/.github/workflows/_reusable_surge-deploy-preview.yml
@@ -1,7 +1,7 @@
 # WARN: this workflow may be reused in other workflows triggered by a workflow_runs.
 
 # Permissions required by this workflow that MUST be set in the calling workflow as this workflow can only downgrade permissions (https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow)
-# pull-requests: write / "afc163/surge-preview@v1" write PR comments when the Surge deployement is done
+# pull-requests: write / "afc163/surge-preview@v1" write PR comments when the Surge deployment is done
 name: Surge deploy preview
 
 on:
@@ -19,7 +19,9 @@ on:
         default: 'master'
 
 jobs:
-  deploy-pr-preview:
+  # MUST be unique across all surge preview deployments for a repository as the job id is used in the deployment URL
+  # IMPORTANT: the logic is duplicated in the `surge-deploy-pr-preview-test.yml` workflow. Keep both definitions in sync.
+  deploy:
     runs-on: ubuntu-22.04
     steps:
       - name: Download artifact
@@ -42,6 +44,3 @@ jobs:
           failOnError: true
           teardown: true
           build: echo "site already built"
-      # Desactivate until the rest of workflow work
-      - name: 🚧 Comments PR with useful links
-        run: echo 'Work in progress'

--- a/.github/workflows/surge-deploy-pr-preview-site.yml
+++ b/.github/workflows/surge-deploy-pr-preview-site.yml
@@ -8,7 +8,6 @@ on:
       - completed
 
 jobs:
-  # MUST be unique across all surge preview deployments for a repository as the job id is used in the deployment URL
   site:
     permissions:
       pull-requests: write # "afc163/surge-preview@v1" write PR comments when the PR is deployed

--- a/.github/workflows/surge-deploy-pr-preview-test.yml
+++ b/.github/workflows/surge-deploy-pr-preview-test.yml
@@ -9,8 +9,29 @@ on:
 
 jobs:
   # MUST be unique across all surge preview deployments for a repository as the job id is used in the deployment URL
+  # IMPORTANT: the logic is duplicated in the `_reusable_surge-deploy-preview.yml` workflow. Keep both definitions in sync.
   test:
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write # "afc163/surge-preview@v1" write PR comments when the PR is deployed
-    uses: ./.github/workflows/_reusable_surge-deploy-preview.yml
-    secrets: inherit
+    steps:
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: site  # must be kept in sync with the artifact name downloaded in the build stage
+          path: build/site
+      - uses: bonitasoft/actions/packages/surge-preview-tools@v3
+        id: surge-preview-tools
+        with:
+          surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
+      - name: Publish preview
+        uses: afc163/surge-preview@v1
+        if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN_DOC }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: build/site
+          failOnError: true
+          teardown: true
+          build: echo "site already built"


### PR DESCRIPTION
This was not working as the 2 workflow used to deployed called the same reusable workflow that deployed to the same URL for the 2 environments. This was because the URL is computed using the job id of the reusable workflow.
So for "test" deployment, duplicate the logic of the reusable workflow to have a dedicated URL.

In the "deploy" reusable workflow, use a shorter job id. It is used to compute the URL of all deployments. A shorter name ensure that we don't try to generate a too large URL subdomain.

The PR comment relative to the changes will be managed by a dedicated workflow in the future for a better separation of concerns, to simplify the maintenance and to make things more explicit. So remove the related steps (that was still a work in progress) from the reusable workflow in charge of the deployment.

Covers #686