### PR TITLE
ci: Adding missing checkout step for reusable worklow

### DIFF
--- a/.github/workflows/_reusable_pr-comment-list-changes.yml
+++ b/.github/workflows/_reusable_pr-comment-list-changes.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
       - uses: actions/checkout@v4 # access to the local action
+        with:
+          repository: 'bonitasoft/bonita-documentation-site'
+          ref: ${{ inputs.doc-site-branch }}
       - name: Publish comments
         uses: ./.github/actions/comment-pr-with-links
         with:


### PR DESCRIPTION
* In reusable, we need to checkout the docSite branch to find our reusable workflow

covers #700 