### PR TITLE
ci(antora-check): forbid API documentation URL

### DIFF
--- a/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml
+++ b/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml
@@ -19,4 +19,4 @@ jobs:
           attributes-to-check: ':description:'
           files-to-check: 'adoc'
           # WARN: Be aware that spaces after/before the coma are not trimmed by the action. This means that the spaces are part of the pattern.
-          forbidden-pattern-to-check: 'https://documentation.bonitasoft.com,link:https,link:http,link:,xref:https,xref:http,xref:_,xref:#,Bonita BPM'
+          forbidden-pattern-to-check: 'https://documentation.bonitasoft.com,link:https,link:http,link:,xref:https,xref:http,xref:_,xref:#,Bonita BPM,https://api-documentation.bonitasoft.com'


### PR DESCRIPTION
*  Adding new forbidden pattern to chuseck:  https://api-documentation.com, we don't want add this to our documentation because we have antora variable to do this