### PR TITLE
chore(dependabot): do not rebase PR when the base branch is updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       time: "05:00"
     open-pull-requests-limit: 2
     versioning-strategy: increase
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`
@@ -18,3 +19,4 @@ updates:
       day: "wednesday"
       time: "05:00"
     open-pull-requests-limit: 2
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Previously, the PRs were all rebased when the master branch changed. This triggered a lot of workflow runs, and new rebase when new PR was merged again.

We prefer doing the PR rebase/update at our own pace and reduce the number of runs.