### PR TITLE
chore: improve logs in the preview script

### DIFF
--- a/build-preview.bash
+++ b/build-preview.bash
@@ -76,13 +76,18 @@ fi
 ########################################################################################################################
 
 # See the node script for the list of arguments
+echo "Use Nodejs $(node --version)"
 node scripts/generate-content-for-preview-antora-playbook.js ${scriptOptions}
 
 if [[ "$scriptOptions" == *"--only-generate-playbook"* ]]; then
   echo "Skip documentation generation"
   exit 0
 fi
-echo "Building the preview using Node $(node --version)..."
 rm -rf build/
+
+echo "Use Antora version:"
+npx antora --version
+
+echo "Building the preview..."
 npx antora --stacktrace antora-playbook-content-for-preview.yml
 echo "Preview built"


### PR DESCRIPTION
Log the version Antora that is used.
This lets validate that we don't use the same Antora version when building the site and when checking the references.

### Notes

Check references
```
Use Antora version:
@antora/cli: 3.2.0-alpha.4
@antora/site-generator: 3.2.0-alpha.4
```

Build site
```
Use Antora version:
@antora/cli: 3.1.7
@antora/site-generator: 3.1.7
```
