### PR TITLE
ci(surge-deploy): try to limit API rate limit errors

### DIFF
--- a/.github/workflows/_reusable_surge-deploy-preview.yml
+++ b/.github/workflows/_reusable_surge-deploy-preview.yml
@@ -30,7 +30,7 @@ jobs:
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
         with:
           surge_token: ${{ secrets.SURGE_TOKEN_DOC }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BONITA_CI_PAT }} # Avoid rate limiting produced with default GITHUB_TOKEN
           dist: build/site
           failOnError: true
           teardown: true

--- a/.github/workflows/_reusable_surge-deploy-preview.yml
+++ b/.github/workflows/_reusable_surge-deploy-preview.yml
@@ -24,6 +24,7 @@ jobs:
         id: surge-preview-tools
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
+          github-token: ${{ secrets.BONITA_CI_PAT }} # Avoid rate limiting produced with default GITHUB_TOKEN
       - name: Publish preview
         uses: afc163/surge-preview@v1
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'

--- a/.github/workflows/_reusable_surge-deploy-preview.yml
+++ b/.github/workflows/_reusable_surge-deploy-preview.yml
@@ -20,7 +20,7 @@ jobs:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: site  # must be kept in sync with the artifact name downloaded in the build stage
           path: build/site
-      - uses: bonitasoft/actions/packages/surge-preview-tools@fix/surge_deploy
+      - uses: bonitasoft/actions/packages/surge-preview-tools@v3
         id: surge-preview-tools
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}

--- a/.github/workflows/_reusable_surge-deploy-preview.yml
+++ b/.github/workflows/_reusable_surge-deploy-preview.yml
@@ -20,7 +20,7 @@ jobs:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: site  # must be kept in sync with the artifact name downloaded in the build stage
           path: build/site
-      - uses: bonitasoft/actions/packages/surge-preview-tools@v3
+      - uses: bonitasoft/actions/packages/surge-preview-tools@fix/surge_deploy
         id: surge-preview-tools
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}

--- a/.github/workflows/surge-deploy-pr-preview-test.yml
+++ b/.github/workflows/surge-deploy-pr-preview-test.yml
@@ -25,12 +25,13 @@ jobs:
         id: surge-preview-tools
         with:
           surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
+          github-token: ${{ secrets.BONITA_CI_PAT }} # Avoid rate limiting produced with default GITHUB_TOKEN
       - name: Publish preview
         uses: afc163/surge-preview@v1
         if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
         with:
           surge_token: ${{ secrets.SURGE_TOKEN_DOC }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BONITA_CI_PAT }} # Avoid rate limiting produced with default GITHUB_TOKEN
           dist: build/site
           failOnError: true
           teardown: true


### PR DESCRIPTION
We currently have rate limit errors when deploying doc PR with surge.

Try using the `BONITA_CI_PAT` instead of `GITHUB_TOKEN` to avoid rate limit error