### PR TITLE
ci(surge-preview): archive the preview site deployed to surge

### DIFF
--- a/.github/workflows/_reusable_surge-deploy-preview.yml
+++ b/.github/workflows/_reusable_surge-deploy-preview.yml
@@ -20,6 +20,13 @@ jobs:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: site  # must be kept in sync with the artifact name downloaded in the build stage
           path: build/site
+      # Give a way to investigate what we try to deploy to surge
+      # See https://github.com/bonitasoft/bonita-documentation-site/issues/741
+      - name: archives preview
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview
+          path: build/site
       - uses: bonitasoft/actions/packages/surge-preview-tools@v3
         id: surge-preview-tools
         with:

--- a/.github/workflows/_reusable_surge-deploy-preview.yml
+++ b/.github/workflows/_reusable_surge-deploy-preview.yml
@@ -20,9 +20,9 @@ jobs:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: site  # must be kept in sync with the artifact name downloaded in the build stage
           path: build/site
-      # Give a way to investigate what we try to deploy to surge
+      # Provide a way to investigate what we try to deploy to surge
       # See https://github.com/bonitasoft/bonita-documentation-site/issues/741
-      - name: archives preview
+      - name: Archive preview
         uses: actions/upload-artifact@v4
         with:
           name: preview


### PR DESCRIPTION
Provide a way to investigate what we try to deploy to surge.

covers #741