### PR TITLE
ci(surge-deploy): get artifact from the specific workflow run

### DIFF
--- a/.github/workflows/_reusable_surge-build-preview.yml
+++ b/.github/workflows/_reusable_surge-build-preview.yml
@@ -31,7 +31,7 @@ on:
         description: 'If `true`, ignores Antora error. Only applies when the `component-name` input is set.'
         required: false
         default: true
-      
+
 
 jobs:
   build-pr-preview:
@@ -85,6 +85,5 @@ jobs:
         if: github.event.action != 'closed'
         uses: actions/upload-artifact@v4
         with:
-          name: site
+          name: site  # must be kept in sync with the artifact name downloaded in the deployment stage
           path: build/site
-        

--- a/.github/workflows/_reusable_surge-deploy-preview.yml
+++ b/.github/workflows/_reusable_surge-deploy-preview.yml
@@ -13,12 +13,14 @@ jobs:
   # IMPORTANT: the logic is duplicated in the `surge-deploy-pr-preview-test.yml` workflow. Keep both definitions in sync.
   deploy:
     runs-on: ubuntu-22.04
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
-          name: site  # must be kept in sync with the artifact name downloaded in the build stage
+          run_id: ${{ github.event.workflow_run.id }}
+          name: site  # must be kept in sync with the artifact name uploaded in the build stage
           path: build/site
       # Provide a way to investigate what we try to deploy to surge
       # See https://github.com/bonitasoft/bonita-documentation-site/issues/741
@@ -40,5 +42,5 @@ jobs:
           github_token: ${{ secrets.BONITA_CI_PAT }} # Avoid rate limiting produced with default GITHUB_TOKEN
           dist: build/site
           failOnError: true
-          teardown: true
+          teardown: false # the teardown is managed in another workflow
           build: echo "site already built"

--- a/.github/workflows/surge-deploy-pr-preview-test.yml
+++ b/.github/workflows/surge-deploy-pr-preview-test.yml
@@ -19,7 +19,8 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
-          name: site  # must be kept in sync with the artifact name downloaded in the build stage
+          run_id: ${{ github.event.workflow_run.id }}
+          name: site  # must be kept in sync with the artifact name uploaded in the build stage
           path: build/site
       - uses: bonitasoft/actions/packages/surge-preview-tools@v3
         id: surge-preview-tools
@@ -34,5 +35,5 @@ jobs:
           github_token: ${{ secrets.BONITA_CI_PAT }} # Avoid rate limiting produced with default GITHUB_TOKEN
           dist: build/site
           failOnError: true
-          teardown: true
+          teardown: false # the teardown is managed in another workflow
           build: echo "site already built"

--- a/.github/workflows/surge-deploy-pr-preview-test.yml
+++ b/.github/workflows/surge-deploy-pr-preview-test.yml
@@ -12,6 +12,7 @@ jobs:
   # IMPORTANT: the logic is duplicated in the `_reusable_surge-deploy-preview.yml` workflow. Keep both definitions in sync.
   test:
     runs-on: ubuntu-22.04
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     permissions:
       pull-requests: write # "afc163/surge-preview@v1" write PR comments when the PR is deployed
     steps:
@@ -21,6 +22,13 @@ jobs:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           run_id: ${{ github.event.workflow_run.id }}
           name: site  # must be kept in sync with the artifact name uploaded in the build stage
+          path: build/site
+      # Provide a way to investigate what we try to deploy to surge
+      # See https://github.com/bonitasoft/bonita-documentation-site/issues/741
+      - name: Archive preview
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview
           path: build/site
       - uses: bonitasoft/actions/packages/surge-preview-tools@v3
         id: surge-preview-tools


### PR DESCRIPTION
Previously, this wasn't set in `dawidd6/action-download-artifact` so the
action was doing a search to retrieve the artifact.
It was using default search parameters, so it skip workflow runs for PR
from forks, and always considered the latest run of the workflow.
So, when several PR was opened simultaneously, a wrong artifact could be
retrieved.

In addition, don't run the deployment workflow if the build step failed.
Fix the fix, the deployment would fail because no artifact is available for download.

### Notes

Fixes #741
Validated with https://github.com/process-analytics/github-actions-playground/pull/363#issuecomment-2205176295

### About the addition of a condition to run the workflow

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
> A workflow run is triggered regardless of the conclusion of the previous workflow. If you want to run a job or step based on the result of the triggering workflow, you can use a conditional with the github.event.workflow_run.conclusion property.
