### PR TITLE
fix:  Path root for file udpate in Root module

### DIFF
--- a/.github/actions/comment-pr-with-links/comments-with-url-links.js
+++ b/.github/actions/comment-pr-with-links/comments-with-url-links.js
@@ -56,8 +56,8 @@ function prepareLinks({files, siteUrl, component, version}) {
         const regex = /modules\/(.*?)\/pages\/(.*?).adoc/;
         const match = file.match(regex);
         if (match) {
-            let moduleName = match[1] === 'ROOT' ? '' : match[1];
-            let url = `${siteUrl}/${component}/${version}/${moduleName}/${match[2]}`;
+            let moduleName = match[1] === 'ROOT' ? '' : `/${match[1]}`;
+            let url = `${siteUrl}/${component}/${version}${moduleName}/${match[2]}`;
             preparedLinks.push(`- [ ] [${moduleName}/${match[2]}](${url})`);
         }
     });


### PR DESCRIPTION
* when the updated file is in ROOT module, the preview link contains // before this PR

An example could be fine here => https://github.com/bonitasoft/bonita-doc/pull/2794