### PR TITLE
ci(validate ref): bump antora from 3.2.0-alpha.5 to 3.2.0-alpha.6

### DIFF
--- a/.github/actions/build-pr-site/action.yml
+++ b/.github/actions/build-pr-site/action.yml
@@ -33,7 +33,7 @@ runs:
       uses: ./.github/actions/build-setup
     - name: Install antora dependencies for xref validation
       shell: bash
-      run: npm install --save-dev antora@3.2.0-alpha.5
+      run: npm install --save-dev antora@3.2.0-alpha.6
     - name: Build Site for a single component
       if: inputs.component-name != ''
       shell: bash


### PR DESCRIPTION
### Notes

Changelog: https://gitlab.com/antora/antora/-/blob/main/CHANGELOG.adoc?ref_type=heads#user-content-3-2-0-alpha-6-2024-07-23