### PR TITLE
chore(gha): bump adrianjost/actions-surge.sh-teardown from 1.0.3 to 1.0.4

### DIFF
--- a/.github/workflows/teardown-inactive-surge-deployments.yml
+++ b/.github/workflows/teardown-inactive-surge-deployments.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Teardown surge deployement inactive than more 1 month
-        uses: adrianjost/actions-surge.sh-teardown@v1.0.3
+        uses: adrianjost/actions-surge.sh-teardown@master
         with:
           regex: '[1-9]+ month.? ago'
         env:

--- a/.github/workflows/teardown-inactive-surge-deployments.yml
+++ b/.github/workflows/teardown-inactive-surge-deployments.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Teardown surge deployement inactive than more 1 month
-        uses: adrianjost/actions-surge.sh-teardown@master
+        uses: adrianjost/actions-surge.sh-teardown@1.0.4
         with:
           regex: '[1-9]+ month.? ago'
         env:

--- a/.github/workflows/teardown-inactive-surge-deployments.yml
+++ b/.github/workflows/teardown-inactive-surge-deployments.yml
@@ -14,7 +14,7 @@ jobs:
   teardown_inactive_deployement:
     runs-on: ubuntu-22.04
     steps:
-      - name: Teardown surge deployement inactive than more 1 month
+      - name: Teardown deployments older than 1 month
         uses: adrianjost/actions-surge.sh-teardown@v1.0.4
         timeout-minutes: 10
         with:

--- a/.github/workflows/teardown-inactive-surge-deployments.yml
+++ b/.github/workflows/teardown-inactive-surge-deployments.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Teardown surge deployement inactive than more 1 month
-        uses: adrianjost/actions-surge.sh-teardown@1.0.4
+        uses: adrianjost/actions-surge.sh-teardown@v1.0.4
         with:
           regex: '[1-9]+ month.? ago'
         env:


### PR DESCRIPTION
The action didn't work after the release of surge 0.24.
The new version 0.1.4 of the action fixes the problem.

### Notes

Closes #771

✔️ Tested with an intermediate commit (master branch): see https://github.com/bonitasoft/bonita-documentation-site/issues/771#issuecomment-2304415900
ℹ️ Tested with the branch of this PR https://github.com/bonitasoft/bonita-documentation-site/actions/runs/10525237283/job/29163605502. There is no deployment to teardown, so this doesn't validate the fix
```
Download action repository 'adrianjost/actions-surge.sh-teardown@v1.0.4' (SHA:f8c2503a1cae5afc57859b9c6afc3fabdbfde027)
...
Run adrianjost/actions-surge.sh-teardown@v1.0.4
DryRun: false
search for projects that match /[1-9]+ month.? ago/i
found 0 projects for teardown
```

Notice that the commit of the v0.1.4 tag is `f8c2503` which is the direct successor of `72e5983` that was tested when using the master branch. The new commit only includes changes related to the CI, so the content of the binary is the same.

--> I have also validated the release with https://github.com/process-analytics/surge.sh-pa-admin/pull/23

![image](https://github.com/user-attachments/assets/59aee614-c0fc-4793-a6c5-8b1f4cd2fd45)

