### PR TITLE
ci(production): fail the Antora build on warnings

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -13,8 +13,8 @@ runtime:
     format: pretty
     # set to info to get details from the Antora extensions
     level: info
-    # Antora exits with a non-zero exit code if an error is logged -> https://docs.antora.org/antora/latest/playbook/runtime-log-failure-level
-    failure_level: error
+    # Antora exits with a non-zero exit code if a warning is logged -> https://docs.antora.org/antora/latest/playbook/runtime-log-failure-level
+    failure_level: warn
 
 content:
   # When adding a new url, add a new entry in generate-content-for-preview-antora-playbook.js to manage PR preview


### PR DESCRIPTION
All branches of the documentation content repositories have been reviewed and fixed to no longer generate warnings. Enabling this feature will prevent from introducing new warnings without being notified.

This has no impact on preview builds: they already configure the log level that make the build fail.

### Notes

Closes #776