### PR TITLE
ci: sign commits in the PR updating the theme

### DIFF
--- a/.github/workflows/update-theme-bundle.yml
+++ b/.github/workflows/update-theme-bundle.yml
@@ -20,7 +20,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT to use a specific user for the git operations
+          token: ${{ secrets.BONITA_CI_PAT }}
+      - name: Setup git
+        uses: bonitasoft/git-setup-action@v1
+        with:
+          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 
       - name: Setup Perl environment
         uses: shogo82148/actions-setup-perl@v1.31.2


### PR DESCRIPTION
Signing commits is a mandatory check in the GitHub rulesets for the default branch of the repository.