### PR TITLE
ci: prohibit direct links with the CSC in the content of documentation

### DIFF
--- a/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml
+++ b/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml
@@ -26,5 +26,5 @@ jobs:
           attributes-to-check: ':description:'
           files-to-check: 'adoc'
           # WARN: Be aware that spaces after/before the coma are not trimmed by the action. This means that the spaces are part of the pattern.
-          forbidden-pattern-to-check: 'https://documentation.bonitasoft.com,link:https,link:http,link:,xref:https,xref:http,xref:_,xref:#,Bonita BPM,https://api-documentation.bonitasoft.com'
+          forbidden-pattern-to-check: 'customer.bonitasoft.com,https://documentation.bonitasoft.com,link:https,link:http,link:,xref:https,xref:http,xref:_,xref:#,Bonita BPM,https://api-documentation.bonitasoft.com'
           steps-to-skip: ${{ inputs.steps-to-skip }}


### PR DESCRIPTION
This check is performed in the PRs of an existing document content repository.
It is recommended to use the AsciiDoc page attribute instead.

### Notes

Such links were present in the bonita content and had been replaced by AsciiDoc attribute in https://github.com/bonitasoft/bonita-doc/commit/71764d964f78afa36240e06a672d7e811584b9c4