### PR TITLE
ci: rename job id of "_reusable_surge-build-preview.yml"

### DIFF
--- a/.github/workflows/_reusable_pr-comment-list-changes.yml
+++ b/.github/workflows/_reusable_pr-comment-list-changes.yml
@@ -16,7 +16,7 @@ on:
         default: "bonita"
 
 jobs:
-  # IMPORTANT: the job id must be the same as in "_reusable_surge-deploy-preview.yml" as the surge-preview-tools action uses it to generate the preview URL (current limitation of v3.2.0)
+  # IMPORTANT: the job id must be the same as in "_reusable_surge-build-preview.yml" and "_reusable_surge-deploy-preview.yml" as the surge-preview-tools action uses it to generate the preview URL (current limitation of v3.2.0)
   deploy:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/_reusable_surge-build-preview.yml
+++ b/.github/workflows/_reusable_surge-build-preview.yml
@@ -34,7 +34,8 @@ on:
 
 
 jobs:
-  build-pr-preview:
+  # IMPORTANT: the job id must be the same as in "_reusable_pr-comment-list-changes.yml" and "_reusable_surge-deploy-preview.yml" as the surge-preview-tools action uses it to generate the preview URL (current limitation of v3.2.0)
+  deploy:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/_reusable_surge-deploy-preview.yml
+++ b/.github/workflows/_reusable_surge-deploy-preview.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   # MUST be unique across all surge preview deployments for a repository as the job id is used in the deployment URL
-  # IMPORTANT: the job id must be the same as in "_reusable_pr-comment-list-changes.yml" as the surge-preview-tools action uses it to generate the preview URL (current limitation of v3.2.0)
+  # IMPORTANT: the job id must be the same as in "_reusable_pr-comment-list-changes.yml" and "_reusable_surge-build-preview.yml" as the surge-preview-tools action uses it to generate the preview URL (current limitation of v3.2.0)
   # IMPORTANT: the logic is duplicated in the `surge-deploy-pr-preview-test.yml` workflow. Keep both definitions in sync.
   deploy:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The current job id is used by the surge-preview to build the deployment URL. This URL is used to build the site and to check its validity. However, it was not the same as the actual one used for deployment as the job id was not the same as in the workflow doing the deployment.
In addition, the former job id was longer so in repository with a long name (like for BCD), the URL was detected as invalid (because it was too long).

The workflow now uses the same job id as in other workflow, which fix all issues.


### Notes

This should fix error like in https://github.com/bonitasoft/bonita-continuous-delivery-doc/actions/runs/13633276913/job/38105740681?pr=228

```
Run bonitasoft/actions/packages/surge-preview-tools@v3
Surge cli version: v0.24.6
Find PR number: 228
Error: The computed surge subdomain is too long. It contains 65 characters, but it must contain a maximum of 63 characters.  
Computed sub-domain: bonitasoft-bonita-continuous-delivery-doc-build-pr-preview-pr-228
In your workflow definition, try to use a shorter id for the job that runs this action.
For more details, see https://github.com/bonitasoft/actions/issues/101
```
