### PR TITLE
fix: display the link to PR in the preview

### DIFF
--- a/.github/workflows/_reusable_surge-build-preview.yml
+++ b/.github/workflows/_reusable_surge-build-preview.yml
@@ -84,6 +84,12 @@ jobs:
       - name: List the content of the generated site
         if: github.event.action != 'closed'
         uses: ./.github/actions/log-built-site-details
+      - name: Upload Antora playbook
+        if: github.event.action != 'closed'
+        uses: actions/upload-artifact@v4
+        with:
+          name: antora-playbook-content-for-preview.yml
+          path: antora-playbook-content-for-preview.yml
       - name: Upload site preview
         if: github.event.action != 'closed'
         uses: actions/upload-artifact@v4

--- a/scripts/generate-content-for-preview-antora-playbook.js
+++ b/scripts/generate-content-for-preview-antora-playbook.js
@@ -75,7 +75,6 @@ console.info('Antora Playbook source file loaded');
 if (useAllComponents) {
     console.info('Documentation content: all components and branches');
     doc.site.title = siteTitle || doc.site.title;
-    getSiteKeys(doc)['pr-link'] = prLink || undefined;
 }
 // single branch per component (site preview)
 else if (useSingleBranchPerComponent) {
@@ -87,7 +86,6 @@ else if (useSingleBranchPerComponent) {
             source.branches = source.branches[source.branches.length - 1];
         });
     doc.site.title = siteTitle || `Preview PR #${prNumber}`;
-    getSiteKeys(doc)['pr-link'] = prLink || undefined;
 }
 // multiple components, each with its own set of branches
 else if (useMultiComponents) {
@@ -275,6 +273,11 @@ const hideNavbarComponentsList = getArgument(argv, 'hide-navbar-components-list'
 console.info(`Hide Navbar Components List: ${hideNavbarComponentsList}`);
 if (hideNavbarComponentsList) {
     getSiteKeys(doc)['hide-navbar-components-list'] = true;
+}
+
+// PR link in the navbar
+if (prLink) {
+    getSiteKeys(doc)['pr-link'] = prLink;
 }
 
 // Ensure we get details where xref resolution fails


### PR DESCRIPTION
The PR link was not always set, particularly when generating a PR preview comprising a single branch.

It is now always set, regardless of the type of preview (single branch, one branch per repository, ...) that is generated.