### PR TITLE
chore: update configuration of htmltest

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,11 +3,13 @@ on:
   schedule:
     - cron: "0 5 * * 3" # every wednesday at 5:00 UTC
   workflow_dispatch:
-    inputs:
-      slack-notifications:
-        type: boolean
-        description: "If checked, send slack notifications when errors occur"
-        default: false
+    # This configuration is commented out because we don't want to send notifications to Slack (see later in this file)
+    # inputs:
+    #   slack-notifications:
+    #     type: boolean
+    #     description: "If checked, send slack notifications when errors occur"
+    #     default: false
+
   # TODO remove this temp configuration, used to test the configuration changes in this PR
   pull_request:
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -8,6 +8,8 @@ on:
         type: boolean
         description: "If checked, send slack notifications when errors occur"
         default: false
+  # TODO remove this temp configuration, used to test the configuration changes in this PR
+  pull_request:
 
 jobs:
   check_links:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -10,9 +10,6 @@ on:
     #     description: "If checked, send slack notifications when errors occur"
     #     default: false
 
-  # TODO remove this temp configuration, used to test the configuration changes in this PR
-  pull_request:
-
 jobs:
   check_links:
     runs-on: ubuntu-22.04

--- a/scripts/htmltest/htmltest_bonita-documentation-site.yml
+++ b/scripts/htmltest/htmltest_bonita-documentation-site.yml
@@ -41,6 +41,8 @@ IgnoreURLs:
   - "openai.com"
   # Only static links use this URL, this is ban by automatic checks in the documentation content
   - "documentation.bonitasoft.com"
+  # In the footer of all pages, this link is not used in the documentation content, so we can ignore it 
+  - "surge.sh"
 
 
 # Simulate a user agent of a real browser, because some sites block requests with the default user agent set by htmltest.


### PR DESCRIPTION
Ignore some site to be more resilient and avoid false positives.


### Notes

When the scheduled task runs  (at 5 am UTC) with the configuration of the current master branch, GitHub returns a lot of HTTP 429 error when checking the URL to the source code like in the following extract 👇🏿 (full logs: 
[check-links-analysis-c3e15a65361b496303e0cf5c9fe49d2f3b0c861a.zip](https://github.com/user-attachments/files/20208840/check-links-analysis-c3e15a65361b496303e0cf5c9fe49d2f3b0c861a.zip)).
This is not reproduced when running with workflow_dispatch or pull_request during the work day.

```
  Non-OK status: 429 --- bonita/2024.2/identity/user-authentication-overview.html --> https://github.com/bonitasoft/bonita-engine/blob/10.1.0/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/servlet/LoginServlet.java
  Non-OK status: 429 --- bonita/2024.2/identity/user-authentication-overview.html --> https://github.com/bonitasoft/bonita-engine/blob/10.1.0/bpm/bonita-web-server/src/main/java/org/bonitasoft/console/common/server/login/LoginManager.java
```