### PR TITLE
feat: Add reusable workflow for nightly image compression

### DIFF
--- a/.github/workflows/_reusable_nightly_compress_image.yml
+++ b/.github/workflows/_reusable_nightly_compress_image.yml
@@ -1,0 +1,42 @@
+# WARN: this workflow may be reused in other workflows triggered by a workflow_dispatch or a cron.
+name: Compress Images Nightly
+on:
+  workflow_call:
+    inputs:
+      pr-title:
+        description: 'Title of the Pull Request to create'
+        type: string
+        default: 'feat: Compressed Images'
+      branch-name:
+        description: 'Name of the branch to create'
+        type: string
+        default: 'feat/compressed-images'
+    secrets:
+      github-token:
+        description: 'GitHub token for authentication'
+        required: true
+
+jobs:
+  compress:
+    name: Compress images on ${{ github.ref_name }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Compress Images
+        id: calibre
+        uses: calibreapp/image-actions@main
+        with:
+          githubToken: ${{ secrets.github-token }}
+          compressOnly: true
+
+      - name: Create New Pull Request If Needed
+        if: steps.calibre.outputs.markdown != ''
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: ${{ inputs.pr-title }} on ${{ github.ref_name }}
+          commit-message: 'feat: Images compressed'
+          branch: ${{ inputs.branch-name }}
+          branch-suffix: 'timestamp'
+          body: ${{ steps.calibre.outputs.markdown }}

--- a/.github/workflows/_reusable_nightly_compress_image.yml
+++ b/.github/workflows/_reusable_nightly_compress_image.yml
@@ -6,11 +6,11 @@ on:
       pr-title:
         description: 'Title of the Pull Request to create'
         type: string
-        default: 'feat: Compressed Images'
+        default: 'refactor: Compressed Images'
       branch-name:
         description: 'Name of the branch to create'
         type: string
-        default: 'feat/compressed-images'
+        default: 'refactor/compressed-images'
     secrets:
       github-token:
         description: 'GitHub token for authentication'
@@ -36,7 +36,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           title: ${{ inputs.pr-title }} on ${{ github.ref_name }}
-          commit-message: 'feat: Images compressed'
+          commit-message: 'refactor: Images compressed'
           branch: ${{ inputs.branch-name }}
           branch-suffix: 'timestamp'
           body: ${{ steps.calibre.outputs.markdown }}

--- a/.github/workflows/compress_nightly.yml
+++ b/.github/workflows/compress_nightly.yml
@@ -1,0 +1,12 @@
+# Compress images on demand (workflow_dispatch), and at 8pm every Monday (schedule).
+# Open a Pull Request if any images can be compressed.
+name: Compress Images Nightly
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '00 8 * * 1'
+jobs:
+  compress-images:
+    uses: ./.github/workflows/_reusable_nightly_compress_image.yml
+    secrets:
+      github-token: ${{ secrets.BONITA_CI_PAT }}


### PR DESCRIPTION
This pull request introduces workflows to automate image compression and streamline the process of creating pull requests for compressed images. The changes include a reusable workflow for nightly image compression and a specific workflow to trigger this process on demand or via a weekly schedule.

### New workflows for image compression:

* [`.github/workflows/_reusable_nightly_compress_image.yml`](diffhunk://#diff-caa26ea82914fe2a941aa13a18ae941614c70f7204282e5970aa6a9103b16e91R1-R42): Added a reusable workflow that compresses images and creates a pull request if any images can be compressed. It supports inputs for pull request title and branch name, and uses the `calibreapp/image-actions` and `peter-evans/create-pull-request` actions.

* [`.github/workflows/compress_nightly.yml`](diffhunk://#diff-ad6e0ff0889cd262d1442f04a8d83cd81786f80f2133ecea954f5f6ffc1743e9R1-R12): Added a workflow that triggers the reusable image compression workflow either on demand (`workflow_dispatch`) or every Monday at 8 PM (`schedule`). It passes the required GitHub token as a secret.

Covers #498 