### PR TITLE
feat: Adapt reusable workflow for nightly image compression

### DIFF
--- a/.github/workflows/_reusable_compress_images_nightly.yml
+++ b/.github/workflows/_reusable_compress_images_nightly.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Compress Images
         id: calibre
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@006692e15ca7d6312e06cc49b57a466d8ed45848
         with:
           githubToken: ${{ secrets.github-token }}
           compressOnly: true

--- a/.github/workflows/compress_nightly.yml
+++ b/.github/workflows/compress_nightly.yml
@@ -7,6 +7,6 @@ on:
     - cron: '00 8 * * 1'
 jobs:
   compress-images:
-    uses: ./.github/workflows/_reusable_nightly_compress_image.yml
+    uses: ./.github/workflows/_reusable_compress_images_nightly.yml
     secrets:
       github-token: ${{ secrets.BONITA_CI_PAT }}


### PR DESCRIPTION
Apply return found on https://github.com/bonitasoft/bonita-doc/pull/3049:

* Homogenise the calibreapp/image-actions to use the same commit
* Rename the nightly reusable action