### PR TITLE
ci: Update run information link in workflow

### DIFF
--- a/.github/workflows/_reusable_compress-images-nightly.yml
+++ b/.github/workflows/_reusable_compress-images-nightly.yml
@@ -53,7 +53,7 @@ jobs:
             
             🔄 This PR has been automatically updated with the latest compressed images.
             
-            _Last updated: Run #${{ github.run_number }} (${{ github.run_id }})_
+            _Last updated: [Run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})_
             _Updated on: ${{ steps.last-commit.outputs.timestamp }}_
           token: ${{ secrets.BONITA_CI_PAT }}
           author: ${{ steps.git-setup.outputs.name}} <${{ steps.git-setup.outputs.email}}>


### PR DESCRIPTION
Fix this issue: 
<img width="563" height="313" alt="image" src="https://github.com/user-attachments/assets/50ce2686-3fff-45ed-b9a0-5273d49f7502" />
