### PR TITLE
chore: add bonita 2026.2

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -29,7 +29,7 @@ jobs:
           --use-multi-repositories
           --component-with-branches bcd:3.6,4.0
           --component-with-branches bpi:main
-          --component-with-branches bonita:archives,2023.2,2024.1,2024.2,2024.3,2025.1,2025.2,2026.1
+          --component-with-branches bonita:archives,2023.2,2024.1,2024.2,2024.3,2025.1,2025.2,2026.1,2026.2
           --component-with-branches central:1.0
           --component-with-branches cloud:master
           --component-with-branches labs:master

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -38,6 +38,7 @@ content:
         - "2025.1"
         - "2025.2"
         - "2026.1"
+        - "2026.2"
     - url: https://github.com/bonitasoft/bonita-labs-doc.git
       branches:
         - "master"

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,6 +16,10 @@ force = true
 # Special redirect after introduction of Bonita branding version
 # Add a new entry when adding a new version/branch. This is generally done when the developments of a new version start
 [[redirects]]
+from = "/bonita/11.1/*"
+to = "/bonita/2026.2/:splat"
+
+[[redirects]]
 from = "/bonita/11.0/*"
 to = "/bonita/2026.1/:splat"
 

--- a/scripts/propagate_doc_upwards.bash
+++ b/scripts/propagate_doc_upwards.bash
@@ -54,6 +54,7 @@ if [ "${REPO_NAME}" == "bonita-doc" ]; then
   merge "2024.3" "2025.1"
   merge "2025.1" "2025.2"
   merge "2025.2" "2026.1"
+  merge "2026.1" "2026.2"
 elif [ "${REPO_NAME}" == "bonita-continuous-delivery-doc" ]; then
   merge "3.6" "4.0"
 elif [ "${REPO_NAME}" == "bonita-test-toolkit-doc" ]; then


### PR DESCRIPTION
## Summary

Add the new development version `2026.2` (platform `11.1.0`) to the documentation site — per [Lifecycle § version-new-in-production](https://bonitasoft.atlassian.net/wiki/spaces/BS/pages/22504964104/Lifecycle+of+the+documentation+of+the+Bonita+Portfolio#version-new-in-production).

## Changes

- `antora-playbook.yml`: add branch `2026.2` for `bonita-doc`
- `scripts/propagate_doc_upwards.bash`: add `merge "2026.1" "2026.2"` at the end of the bonita chain
- `netlify.toml`: add technical-id → product-version redirect `/bonita/11.1/* → /bonita/2026.2/:splat`
- `.github/workflows/check-links.yml`: add `2026.2` to the bonita branches list

## Test plan

- [ ] Run manually the [Propagate documentation workflow](https://github.com/bonitasoft/bonita-documentation-site/actions/workflows/propagate-doc-upwards.yml) on this PR's branch and fix any 2026.2-related error
- [ ] Preview the site and check the new version is visible
- [ ] Review from Doc-site Team