### PR TITLE
feat: remove some bonita archived versions from the site

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -26,9 +26,6 @@ content:
     - url: https://github.com/bonitasoft/bonita-doc.git
       branches:
         - "archives"
-        - "2021.1"
-        - "2021.2"
-        - "2022.1"
         - "2022.2"
         - "2023.1"
         - "2023.2"

--- a/netlify.toml
+++ b/netlify.toml
@@ -66,17 +66,6 @@ to = "/bonita/2023.1/:splat"
 from = "/bonita/7.15/*"
 to = "/bonita/2022.2/:splat"
 
-[[redirects]]
-from = "/bonita/7.14/*"
-to = "/bonita/2022.1/:splat"
-
-[[redirects]]
-from = "/bonita/7.13/*"
-to = "/bonita/2021.2/:splat"
-
-[[redirects]]
-from = "/bonita/7.12/*"
-to = "/bonita/2021.1/:splat"
 
 ########################################
 # Special redirections from Bonita Old contents about UIB to the new UIB component
@@ -103,7 +92,28 @@ to = "/ui-builder/latest/:splat"
 # Bonita Old Documentation redirects to Archives
 ########################################
 # Add a new entry when archiving a version
-# Starting from version 7.12, when adding a redirect here, remove the redirect defined above in "Special redirect after introduction of Bonita branding version"
+# Starting from version 2021.1/7.12, when adding a redirect here, move the redirect defined above in "Special redirect after introduction of Bonita branding version" here and rediret it to latest instead of the specific version.
+[[redirects]]
+from = "/bonita/2022.1/*"
+to = "/bonita/latest/:splat"
+[[redirects]]
+from = "/bonita/7.14/*"
+to = "/bonita/latest/:splat"
+
+[[redirects]]
+from = "/bonita/2021.2/*"
+to = "/bonita/latest/:splat"
+[[redirects]]
+from = "/bonita/7.13/*"
+to = "/bonita/latest/:splat"
+
+[[redirects]]
+from = "/bonita/2021.1/*"
+to = "/bonita/latest/:splat"
+[[redirects]]
+from = "/bonita/7.12/*"
+to = "/bonita/latest/:splat"
+
 [[redirects]]
 from = "/bonita/7.11/*"
 to = "/bonita/latest/:splat"


### PR DESCRIPTION
Archived versions: 2021.1, 2021.2, 2022.1
Redirect related contents to the latest versions as done for former archived versions.

### Notes

Tested locally by building the whole site (no xref errors) and checking redirects with the dev server.