### PR TITLE
fix: use right redirect rule for bonitasoft.com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@ to = "https://documentation.ofelia.com/:splat"
 force = true
 
 [[redirects]]
-from = "https://documentation.bonitasoft.com/:splat/*"
+from = "https://documentation.bonitasoft.com/*"
 to = "https://documentation.ofelia.com/:splat"
 force = true
 


### PR DESCRIPTION
The former configuration introduced extra "splat" settings which were wrongly positioned.
This now uses the same syntax as for the "bonitasoft preview" URL.