### PR TITLE
feat: remove bonita 2022.2 and bcd 3.6

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   check_links:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6 # access to the local action
       - name: Build Setup
@@ -27,7 +27,7 @@ jobs:
           --ignore-errors true
           --fail-on-warning false
           --use-multi-repositories
-          --component-with-branches bcd:3.6,4.0
+          --component-with-branches bcd:4.0
           --component-with-branches bpi:main
           --component-with-branches bonita:archives,2023.2,2024.1,2024.2,2024.3,2025.1,2025.2,2026.1,2026.2
           --component-with-branches cloud:master

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   check_links:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read # to checkout the code
     steps:
       - uses: actions/checkout@v6 # access to the local action
       - name: Build Setup

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -30,11 +30,12 @@ jobs:
           --fail-on-warning false
           --use-multi-repositories
           --component-with-branches bcd:4.0
-          --component-with-branches bpi:main
           --component-with-branches bonita:archives,2023.2,2024.1,2024.2,2024.3,2025.1,2025.2,2026.1,2026.2
+          --component-with-branches bpi:main
           --component-with-branches cloud:master
           --component-with-branches labs:master
           --component-with-branches test-toolkit:1.0,2.0,3.0,3.1
+          --component-with-branches ui-builder:1.3
       - name: List the content of the generated site
         uses: ./.github/actions/log-built-site-details
       - name: Remove pages that we don't want to check

--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -15,13 +15,12 @@ on:
 
 jobs:
   propagate-doc-upwards:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
         repo:
-          - bonita-continuous-delivery-doc
           - bonita-doc
           - bonita-test-toolkit-doc
     steps:

--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   propagate-doc-upwards:
     runs-on: ubuntu-24.04
+    permissions: {} # no permissions needed as we use a dedicated token with specific permissions for the checkout action
     strategy:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -29,7 +29,6 @@ content:
     - url: https://github.com/bonitasoft/bonita-doc.git
       branches:
         - "archives"
-        - "2022.2"
         - "2023.1"
         - "2023.2"
         - "2024.1"

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -43,7 +43,6 @@ content:
         - "master"
     - url: https://github.com/bonitasoft/bonita-continuous-delivery-doc.git
       branches:
-        - "3.6"
         - "4.0"
     - url: https://github.com/bonitasoft/bonita-test-toolkit-doc.git
       branches:

--- a/netlify.toml
+++ b/netlify.toml
@@ -224,6 +224,10 @@ to = "/bcd/latest/"
 
 # Archives
 [[redirects]]
+from = "/bcd/3.6/*"
+to = "/bcd/latest/:splat"
+
+[[redirects]]
 from = "/bcd/3.5/*"
 to = "/bcd/latest/:splat"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -67,10 +67,6 @@ to = "/bonita/2023.1/:splat"
 from = "/bonita/7.16/*"
 to = "/bonita/2023.1/:splat"
 
-[[redirects]]
-from = "/bonita/7.15/*"
-to = "/bonita/2022.2/:splat"
-
 
 ########################################
 # Special redirections from Bonita Old contents about UIB to the new UIB component
@@ -98,6 +94,13 @@ to = "/ui-builder/latest/:splat"
 ########################################
 # Add a new entry when archiving a version
 # Starting from version 2021.1/7.12, when adding a redirect here, move the redirect defined above in "Special redirect after introduction of Bonita branding version" here and rediret it to latest instead of the specific version.
+[[redirects]]
+from = "/bonita/2022.2/*"
+to = "/bonita/latest/:splat"
+[[redirects]]
+from = "/bonita/7.15/*"
+to = "/bonita/latest/:splat"
+
 [[redirects]]
 from = "/bonita/2022.1/*"
 to = "/bonita/latest/:splat"

--- a/scripts/htmltest/htmltest_bonita-documentation-site.yml
+++ b/scripts/htmltest/htmltest_bonita-documentation-site.yml
@@ -41,6 +41,9 @@ IgnoreURLs:
   # Non-OK status: 400 --> https://www.facebook.com/bonitasoftbpm
   - "www.facebook.com/bonitasoftbpm"
   - "surge.sh"
+  # Starting from 2026-05-19, LinkedIn is returning a 429 Too Many Requests
+  - "linkedin.com/company/bonitasoft"
+  - "linkedin.com/company/ofelia"
   # Twitter requires authentication
   - "twitter.com/bonitasoft"
   - "x.com/bonitasoft"

--- a/scripts/propagate_doc_upwards.bash
+++ b/scripts/propagate_doc_upwards.bash
@@ -55,8 +55,6 @@ if [ "${REPO_NAME}" == "bonita-doc" ]; then
   merge "2025.1" "2025.2"
   merge "2025.2" "2026.1"
   merge "2026.1" "2026.2"
-elif [ "${REPO_NAME}" == "bonita-continuous-delivery-doc" ]; then
-  merge "3.6" "4.0"
 elif [ "${REPO_NAME}" == "bonita-test-toolkit-doc" ]; then
   merge "1.0" "2.0"
   merge "2.0" "3.0"


### PR DESCRIPTION
The bonita 2022.2 documentation is archived. It should have been removed as part of ee424810.
bcd 3.6 supports only versions equal or prior to bonita 2022.2, so it becomes useless with the removal of bonita 2022.2. Then is is also removed.

In addition, the check of external links is now also done for uib 1.3. The bonitasoft/ofelia LinkedIn page is not longer checked.

### Notes

I have tested locally the build of the whole site.
bcd 3.6 archive available in the archives location, see https://github.com/bonitasoft/bonita-doc/pull/3358