### PR TITLE
feat: stop propagating bcd contents from 3.6 to 4.0

### DIFF
--- a/.github/workflows/propagate-doc-upwards.yml
+++ b/.github/workflows/propagate-doc-upwards.yml
@@ -15,13 +15,12 @@ on:
 
 jobs:
   propagate-doc-upwards:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       # we want to run the full build on all os: don't cancel running jobs even if one fails
       fail-fast: false
       matrix:
         repo:
-          - bonita-continuous-delivery-doc
           - bonita-doc
           - bonita-test-toolkit-doc
     steps:

--- a/scripts/propagate_doc_upwards.bash
+++ b/scripts/propagate_doc_upwards.bash
@@ -55,8 +55,6 @@ if [ "${REPO_NAME}" == "bonita-doc" ]; then
   merge "2025.1" "2025.2"
   merge "2025.2" "2026.1"
   merge "2026.1" "2026.2"
-elif [ "${REPO_NAME}" == "bonita-continuous-delivery-doc" ]; then
-  merge "3.6" "4.0"
 elif [ "${REPO_NAME}" == "bonita-test-toolkit-doc" ]; then
   merge "1.0" "2.0"
   merge "2.0" "3.0"


### PR DESCRIPTION
Branch 3.6 will be removed from the public website and will no longer be updated.